### PR TITLE
Display icons only in toolbar buttons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -145,11 +145,6 @@ body{
 .toast.success{border-color:var(--accent-2)}
 .toast.fade{opacity:0; transition:opacity .3s ease}
 
-/* Buttons text label on narrow screens */
-@media (max-width: 640px){
-  .btn span{display:none}
-}
-
 /* High contrast focus vis */
 :focus-visible{scroll-margin: 100px}
 

--- a/index.html
+++ b/index.html
@@ -12,47 +12,47 @@
     <nav role="toolbar" aria-label="Formatting">
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>
       <button id="btnLoad" class="btn" title="Load .md file" aria-label="Load">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Load</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg>
       </button>
       <button id="btnExport" class="btn" title="Export as Markdown" aria-label="Export">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Export</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg>
       </button>
       <button id="btnSource" class="btn" title="Toggle source view" aria-pressed="false" aria-label="Source">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Source</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg>
       </button>
 
       <span class="spacer" aria-hidden="true"></span>
 
       <button id="btnBold" class="btn" title="Bold  Ctrl or Cmd+B" aria-label="Bold">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#bold"/></svg><span>B</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#bold"/></svg>
       </button>
       <button id="btnItalic" class="btn" title="Italic  Ctrl or Cmd+I" aria-label="Italic">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#italic"/></svg><span>I</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#italic"/></svg>
       </button>
       <button id="btnStrike" class="btn" title="Strikethrough  Ctrl or Cmd+E" aria-label="Strikethrough">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#strike"/></svg><span>S</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#strike"/></svg>
       </button>
 
       <div class="sep" aria-hidden="true"></div>
 
       <button data-h="1" class="btn btn-h" title="Heading 1  Ctrl or Cmd+1" aria-label="Heading 1">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h1"/></svg><span>H1</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h1"/></svg>
       </button>
       <button data-h="2" class="btn btn-h" title="Heading 2  Ctrl or Cmd+2" aria-label="Heading 2">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h2"/></svg><span>H2</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h2"/></svg>
       </button>
       <button data-h="3" class="btn btn-h" title="Heading 3  Ctrl or Cmd+3" aria-label="Heading 3">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h3"/></svg><span>H3</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h3"/></svg>
       </button>
       <button data-h="4" class="btn btn-h" title="Heading 4  Ctrl or Cmd+4" aria-label="Heading 4">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h4"/></svg><span>H4</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h4"/></svg>
       </button>
 
       <div class="sep" aria-hidden="true"></div>
 
       <div class="table-wrap">
         <button id="btnTable" class="btn" title="Insert table" aria-expanded="false" aria-controls="tablePicker" aria-label="Insert table">
-          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#table"/></svg><span>Table</span>
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#table"/></svg>
         </button>
         <div id="tablePicker" class="table-picker" role="dialog" aria-modal="false" aria-label="Insert table size">
           <div class="grid" aria-hidden="true"></div>
@@ -62,10 +62,10 @@
       </div>
 
       <button class="btn" title="Insert image  (stub)" aria-disabled="true" disabled>
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#image"/></svg><span>Image</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#image"/></svg>
       </button>
       <button class="btn" title="Insert link  (stub)" aria-disabled="true" disabled>
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#link"/></svg><span>Link</span>
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#link"/></svg>
       </button>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- Show only SVG icons in toolbar buttons and remove letter labels
- Drop unused CSS for hidden button text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77a789a1c833290eabf4a029434e0