### PR TITLE
Add keyboard shortcut sidebar and theme toggle

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -20,6 +20,7 @@
   const tableHint = $('#tableHint');
   const btnTable = $('#btnTable');
   const toasts = $('#toasts');
+  const root = document.documentElement;
 
   function toast(msg, cls = '') {
     const el = document.createElement('div');
@@ -199,6 +200,11 @@
     toast('Exported ' + name, 'success');
   }
 
+  function toggleTheme(){
+    const current = root.getAttribute('data-theme');
+    root.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
+  }
+
   // File loading
   btnLoad.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', async (e) => {
@@ -353,6 +359,9 @@
     else if (k === 'i'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('italic'); normaliseInlineTags(); } }
     else if (k === 'e'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('strikeThrough'); normaliseInlineTags(); } }
     else if (['1','2','3','4'].includes(k)){ e.preventDefault(); applyHeading(+k); }
+    else if (k === '/'){ e.preventDefault(); toggleSource(); }
+    else if (k === 's'){ e.preventDefault(); exportMarkdown(); }
+    else if (k === 'd'){ e.preventDefault(); toggleTheme(); }
   });
 
   // Basic startup

--- a/assets/style.css
+++ b/assets/style.css
@@ -27,6 +27,32 @@
   }
 }
 
+:root[data-theme="light"]{
+  --bg: #ffffff;
+  --fg: #0f172a;
+  --muted: #64748b;
+  --edge: #e5e7eb;
+  --ring: #2563eb;
+  --accent: #0ea5e9;
+  --accent-2: #10b981;
+  --warn: #b91c1c;
+  --table-odd: #f8fafc;
+  --surface: #ffffff;
+}
+
+:root[data-theme="dark"]{
+  --bg: #0b1020;
+  --fg: #e5e7eb;
+  --muted: #9aa5b1;
+  --edge: #1f2937;
+  --ring: #60a5fa;
+  --accent: #38bdf8;
+  --accent-2: #34d399;
+  --warn: #ef4444;
+  --table-odd: #0f172a;
+  --surface: #0c1426;
+}
+
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
@@ -155,3 +181,34 @@ body{
 
 /* Disable contenteditable outlines on nested cells */
 table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
+
+/* Shortcuts sidebar */
+.shortcuts{
+  position:fixed;
+  top:3.5rem;
+  right:0;
+  width:200px;
+  height:calc(100% - 3.5rem);
+  padding:1rem;
+  background:var(--surface);
+  border-left:1px solid var(--edge);
+  overflow-y:auto;
+  font-size:.9rem;
+  z-index:40;
+}
+.shortcuts h2{
+  margin-top:0;
+  font-size:1rem;
+}
+.shortcuts ul{list-style:none; margin:0; padding:0}
+.shortcuts li{margin:.3rem 0}
+.shortcuts kbd{
+  background:var(--edge);
+  padding:0 .25rem;
+  border-radius:3px;
+  font-size:.8rem;
+}
+
+@media (min-width:900px){
+  #main{margin-right:220px}
+}

--- a/index.html
+++ b/index.html
@@ -77,6 +77,19 @@
     </section>
   </main>
 
+  <aside class="shortcuts" aria-label="Keyboard shortcuts">
+    <h2>Shortcuts</h2>
+    <ul>
+      <li><kbd>Ctrl</kbd> + <kbd>B</kbd> Bold</li>
+      <li><kbd>Ctrl</kbd> + <kbd>I</kbd> Italic</li>
+      <li><kbd>Ctrl</kbd> + <kbd>E</kbd> Strikethrough</li>
+      <li><kbd>Ctrl</kbd> + <kbd>1</kbd>–<kbd>4</kbd> Headings</li>
+      <li><kbd>Ctrl</kbd> + <kbd>/</kbd> Source view</li>
+      <li><kbd>Ctrl</kbd> + <kbd>D</kbd> Dark mode</li>
+      <li><kbd>Ctrl</kbd> + <kbd>S</kbd> Download</li>
+    </ul>
+  </aside>
+
   <div id="toasts" class="toasts" aria-live="polite" aria-atomic="true"></div>
 
   <!-- Vendor libs -->


### PR DESCRIPTION
## Summary
- Display keyboard shortcut reference in a fixed sidebar
- Support Ctrl+/ for source mode, Ctrl+S to download, and Ctrl+D to toggle theme
- Enable manual light/dark themes via data-theme attribute

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68a77b49eb1083329f1de61ff27037c9