### PR TITLE
Improve toolbar labels and keyboard shortcuts

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10,7 +10,7 @@
   const dropZone = $('#dropZone');
   const btnLoad = $('#btnLoad');
   const btnExport = $('#btnExport');
-  const btnSource = $('#btnSource');
+  const btnAdvanced = $('#btnAdvanced');
   const btnBold = $('#btnBold');
   const btnItalic = $('#btnItalic');
   const btnStrike = $('#btnStrike');
@@ -21,6 +21,8 @@
   const btnTable = $('#btnTable');
   const toasts = $('#toasts');
   const root = document.documentElement;
+  const shortcutsPanel = $('#shortcuts');
+  const toggleShortcuts = $('#toggleShortcuts');
 
   function toast(msg, cls = '') {
     const el = document.createElement('div');
@@ -260,7 +262,7 @@
     document.execCommand('insertText', false, text);
   });
 
-  // Source toggle
+  // Advanced toggle
   function toggleSource(forceToSource) {
     const toSource = typeof forceToSource === 'boolean' ? forceToSource : (mode === 'wysiwyg');
     if (toSource) {
@@ -272,7 +274,7 @@
       editor.style.display = 'none';
       srcTA.style.display = 'block';
       srcTA.focus();
-      btnSource.setAttribute('aria-pressed', 'true');
+      btnAdvanced.setAttribute('aria-pressed', 'true');
       mode = 'source';
     } else {
       // textarea -> html
@@ -281,7 +283,7 @@
       srcTA.style.display = 'none';
       editor.style.display = 'block';
       editor.focus();
-      btnSource.setAttribute('aria-pressed', 'false');
+      btnAdvanced.setAttribute('aria-pressed', 'false');
       mode = 'wysiwyg';
     }
   }
@@ -346,8 +348,14 @@
 
   $$('.btn-h').forEach(b => b.addEventListener('click', () => { editor.focus(); applyHeading(+b.dataset.h); }));
 
-  btnSource.addEventListener('click', () => toggleSource());
+  btnAdvanced.addEventListener('click', () => toggleSource());
   btnExport.addEventListener('click', exportMarkdown);
+  toggleShortcuts.addEventListener('click', () => {
+    const collapsed = shortcutsPanel.classList.toggle('collapsed');
+    toggleShortcuts.setAttribute('aria-expanded', String(!collapsed));
+    toggleShortcuts.textContent = collapsed ? '≡' : '×';
+    document.body.classList.toggle('shortcuts-collapsed', collapsed);
+  });
 
   // Keyboard shortcuts
   document.addEventListener('keydown', (e) => {
@@ -359,9 +367,9 @@
     else if (k === 'i'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('italic'); normaliseInlineTags(); } }
     else if (k === 'e'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('strikeThrough'); normaliseInlineTags(); } }
     else if (['1','2','3','4'].includes(k)){ e.preventDefault(); applyHeading(+k); }
-    else if (k === '/'){ e.preventDefault(); toggleSource(); }
+    else if (e.altKey && k === 'a'){ e.preventDefault(); toggleSource(); }
+    else if (e.altKey && k === 'd'){ e.preventDefault(); toggleTheme(); }
     else if (k === 's'){ e.preventDefault(); exportMarkdown(); }
-    else if (k === 'd'){ e.preventDefault(); toggleTheme(); }
   });
 
   // Basic startup

--- a/assets/style.css
+++ b/assets/style.css
@@ -190,7 +190,21 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
   overflow-y:auto;
   font-size:.9rem;
   z-index:40;
+  transition:transform .3s;
 }
+.shortcuts.collapsed{transform:translateX(100%)}
+.shortcuts .toggle{
+  position:absolute;
+  left:-1.5rem;
+  top:.5rem;
+  padding:.25rem .3rem;
+  border:1px solid var(--edge);
+  border-right:none;
+  background:var(--surface);
+  border-radius:.5rem 0 0 .5rem;
+  cursor:pointer;
+}
+.shortcuts.collapsed .toggle{transform:translateX(-100%)}
 .shortcuts h2{
   margin-top:0;
   font-size:1rem;
@@ -205,5 +219,5 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
 }
 
 @media (min-width:900px){
-  #main{margin-right:220px}
+  body:not(.shortcuts-collapsed) #main{margin-right:220px}
 }

--- a/index.html
+++ b/index.html
@@ -11,18 +11,6 @@
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">
     <nav role="toolbar" aria-label="Formatting">
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>
-      <button id="btnLoad" class="btn" title="Load .md file" aria-label="Load">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg>
-      </button>
-      <button id="btnExport" class="btn" title="Export as Markdown" aria-label="Export">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg>
-      </button>
-      <button id="btnSource" class="btn" title="Toggle source view" aria-pressed="false" aria-label="Source">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg>
-      </button>
-
-      <span class="spacer" aria-hidden="true"></span>
-
       <button id="btnBold" class="btn" title="Bold  Ctrl or Cmd+B" aria-label="Bold">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#bold"/></svg>
       </button>
@@ -67,6 +55,18 @@
       <button class="btn" title="Insert link  (stub)" aria-disabled="true" disabled>
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#link"/></svg>
       </button>
+
+      <span class="spacer" aria-hidden="true"></span>
+
+      <button id="btnLoad" class="btn" title="Upload .md file" aria-label="Upload">
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Upload</span>
+      </button>
+      <button id="btnExport" class="btn" title="Download Markdown" aria-label="Download">
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Download</span>
+      </button>
+      <button id="btnAdvanced" class="btn" title="Toggle advanced mode" aria-pressed="false" aria-label="Advanced">
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
+      </button>
     </nav>
   </header>
 
@@ -77,15 +77,16 @@
     </section>
   </main>
 
-  <aside class="shortcuts" aria-label="Keyboard shortcuts">
+  <aside id="shortcuts" class="shortcuts" aria-label="Keyboard shortcuts">
+    <button id="toggleShortcuts" class="toggle" aria-expanded="true" aria-label="Hide shortcuts">×</button>
     <h2>Shortcuts</h2>
     <ul>
       <li><kbd>Ctrl</kbd> + <kbd>B</kbd> Bold</li>
       <li><kbd>Ctrl</kbd> + <kbd>I</kbd> Italic</li>
       <li><kbd>Ctrl</kbd> + <kbd>E</kbd> Strikethrough</li>
       <li><kbd>Ctrl</kbd> + <kbd>1</kbd>–<kbd>4</kbd> Headings</li>
-      <li><kbd>Ctrl</kbd> + <kbd>/</kbd> Source view</li>
-      <li><kbd>Ctrl</kbd> + <kbd>D</kbd> Dark mode</li>
+      <li><kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>A</kbd> Advanced mode</li>
+      <li><kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>D</kbd> Dark mode</li>
       <li><kbd>Ctrl</kbd> + <kbd>S</kbd> Download</li>
     </ul>
   </aside>


### PR DESCRIPTION
## Summary
- Show text labels for Upload, Download, and Advanced mode and move them to the right of formatting controls
- Add a collapsible shortcuts sidebar with updated key combos
- Switch to Ctrl+Alt+A for Advanced mode and Ctrl+Alt+D for Dark mode

## Testing
- `node --check assets/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77d3af5f08332a8e00c9f3def5e63