### PR TITLE
Restore source toggle shortcut and fix toolbar IDs

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10,7 +10,7 @@
   const dropZone = $('#dropZone');
   const btnLoad = $('#btnLoad');
   const btnExport = $('#btnExport');
-  const btnAdvanced = $('#btnAdvanced');
+  const btnSource = $('#btnSource');
   const btnBold = $('#btnBold');
   const btnItalic = $('#btnItalic');
   const btnStrike = $('#btnStrike');
@@ -274,7 +274,7 @@
       editor.style.display = 'none';
       srcTA.style.display = 'block';
       srcTA.focus();
-      btnAdvanced.setAttribute('aria-pressed', 'true');
+      btnSource.setAttribute('aria-pressed', 'true');
       mode = 'source';
     } else {
       // textarea -> html
@@ -283,7 +283,7 @@
       srcTA.style.display = 'none';
       editor.style.display = 'block';
       editor.focus();
-      btnAdvanced.setAttribute('aria-pressed', 'false');
+      btnSource.setAttribute('aria-pressed', 'false');
       mode = 'wysiwyg';
     }
   }
@@ -348,7 +348,7 @@
 
   $$('.btn-h').forEach(b => b.addEventListener('click', () => { editor.focus(); applyHeading(+b.dataset.h); }));
 
-  btnAdvanced.addEventListener('click', () => toggleSource());
+  btnSource.addEventListener('click', () => toggleSource());
   btnExport.addEventListener('click', exportMarkdown);
   toggleShortcuts.addEventListener('click', () => {
     const collapsed = shortcutsPanel.classList.toggle('collapsed');
@@ -367,8 +367,8 @@
     else if (k === 'i'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('italic'); normaliseInlineTags(); } }
     else if (k === 'e'){ e.preventDefault(); if (mode==='wysiwyg'){ document.execCommand('strikeThrough'); normaliseInlineTags(); } }
     else if (['1','2','3','4'].includes(k)){ e.preventDefault(); applyHeading(+k); }
-    else if (e.altKey && k === 'a'){ e.preventDefault(); toggleSource(); }
-    else if (e.altKey && k === 'd'){ e.preventDefault(); toggleTheme(); }
+    else if (k === '/'){ e.preventDefault(); toggleSource(); }
+    else if (k === 'd'){ e.preventDefault(); toggleTheme(); }
     else if (k === 's'){ e.preventDefault(); exportMarkdown(); }
   });
 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
       <button id="btnExport" class="btn" title="Download Markdown" aria-label="Download">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Download</span>
       </button>
-      <button id="btnAdvanced" class="btn" title="Toggle advanced mode" aria-pressed="false" aria-label="Advanced">
+      <button id="btnSource" class="btn" title="Toggle advanced mode  Ctrl or Cmd+/" aria-pressed="false" aria-label="Advanced">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
       </button>
     </nav>
@@ -85,8 +85,8 @@
       <li><kbd>Ctrl</kbd> + <kbd>I</kbd> Italic</li>
       <li><kbd>Ctrl</kbd> + <kbd>E</kbd> Strikethrough</li>
       <li><kbd>Ctrl</kbd> + <kbd>1</kbd>–<kbd>4</kbd> Headings</li>
-      <li><kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>A</kbd> Advanced mode</li>
-      <li><kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>D</kbd> Dark mode</li>
+      <li><kbd>Ctrl</kbd> + <kbd>/</kbd> Advanced mode</li>
+      <li><kbd>Ctrl</kbd> + <kbd>D</kbd> Dark mode</li>
       <li><kbd>Ctrl</kbd> + <kbd>S</kbd> Download</li>
     </ul>
   </aside>


### PR DESCRIPTION
## Summary
- Restore original `Ctrl+/` shortcut for advanced/source mode toggle
- Revert internal button ID to `btnSource` while keeping "Advanced" label
- Update shortcut list and titles accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a783253bb88332bfada0b7c6116f13