### PR TITLE
Add link and image insertion with base64 embedding

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,6 +7,7 @@
   const editor = $('#editor');
   const srcTA = $('#source');
   const fileInput = $('#fileInput');
+  const imgInput = $('#imgInput');
   const dropZone = $('#dropZone');
   const btnLoad = $('#btnLoad');
   const btnExport = $('#btnExport');
@@ -14,6 +15,8 @@
   const btnBold = $('#btnBold');
   const btnItalic = $('#btnItalic');
   const btnStrike = $('#btnStrike');
+  const btnImage = $('#btnImage');
+  const btnLink = $('#btnLink');
   const tableWrap = $('.table-wrap');
   const tablePicker = $('#tablePicker');
   const tableGrid = tablePicker.querySelector('.grid');
@@ -402,6 +405,35 @@
   btnBold.addEventListener('click', () => { editor.focus(); document.execCommand('bold'); normaliseInlineTags(); });
   btnItalic.addEventListener('click', () => { editor.focus(); document.execCommand('italic'); normaliseInlineTags(); });
   btnStrike.addEventListener('click', () => { editor.focus(); document.execCommand('strikeThrough'); normaliseInlineTags(); });
+  btnImage.addEventListener('click', () => { if (mode !== 'wysiwyg') return; imgInput.click(); });
+  btnLink.addEventListener('click', () => {
+    if (mode !== 'wysiwyg') return;
+    const url = prompt('URL', 'https://');
+    if (!url) return;
+    editor.focus();
+    const sel = window.getSelection();
+    if (sel && !sel.isCollapsed) {
+      document.execCommand('createLink', false, url);
+    } else {
+      const text = prompt('Link text', url);
+      if (!text) return;
+      document.execCommand('insertHTML', false, `<a href="${url}">${text}</a>`);
+    }
+  });
+  imgInput.addEventListener('change', () => {
+    const file = imgInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      editor.focus();
+      const dataUrl = reader.result;
+      const alt = prompt('Alt text', '') || '';
+      const safeAlt = alt.replace(/"/g, '&quot;');
+      document.execCommand('insertHTML', false, `<img src="${dataUrl}" alt="${safeAlt}">`);
+    };
+    reader.readAsDataURL(file);
+    imgInput.value = '';
+  });
 
   $$('.btn-h').forEach(b => b.addEventListener('click', () => { editor.focus(); applyHeading(+b.dataset.h); }));
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">
     <nav role="toolbar" aria-label="Formatting">
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>
+      <input id="imgInput" type="file" accept="image/*" hidden>
       <button id="btnBold" class="btn" title="Bold  Ctrl or Cmd+B" aria-label="Bold">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#bold"/></svg>
       </button>
@@ -53,10 +54,10 @@
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#chart"/></svg>
       </button>
 
-      <button class="btn" title="Insert image  (stub)" aria-disabled="true" disabled>
+      <button id="btnImage" class="btn" title="Insert image" aria-label="Insert image">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#image"/></svg>
       </button>
-      <button class="btn" title="Insert link  (stub)" aria-disabled="true" disabled>
+      <button id="btnLink" class="btn" title="Insert link" aria-label="Insert link">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#link"/></svg>
       </button>
 


### PR DESCRIPTION
## Summary
- Enable toolbar buttons for inserting links and images
- Support image uploads as base64 data URLs for portable markdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78a5cf8288332aefd92a007e3da5d