### PR TITLE
Add frontmatter editor and fix chart insertion

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -116,6 +116,22 @@ body{
 .chart-builder .preview{border:1px solid var(--edge); border-radius:.3rem; padding:.4rem; min-height:60px; margin-bottom:.5rem}
 .chart-builder .actions{display:flex; justify-content:flex-end; gap:.5rem}
 
+/* Frontmatter editor */
+.frontmatter-wrap{position:relative}
+.frontmatter-editor{
+  position:absolute; top:2.6rem; left:0; border:1px solid var(--edge); background:var(--surface);
+  border-radius:.5rem; box-shadow:0 6px 24px rgba(0,0,0,.12); padding:.5rem; display:none; z-index:50; width:260px;
+}
+.frontmatter-editor.open{display:block}
+.frontmatter-editor .row{display:flex; gap:.5rem; margin-bottom:.5rem}
+.frontmatter-editor .row input{flex:1; padding:.3rem .4rem; border:1px solid var(--edge); border-radius:.3rem}
+.frontmatter-editor .row .add{padding:.3rem .5rem; border:1px solid var(--edge); background:#fff0; border-radius:.3rem; cursor:pointer}
+.frontmatter-editor .row .add:hover{background:var(--edge)}
+.frontmatter-editor ul{list-style:none; padding:0; margin:0 0 .5rem 0}
+.frontmatter-editor li{display:flex; justify-content:space-between; align-items:center; margin-bottom:.25rem}
+.frontmatter-editor li button{border:none; background:#fff0; cursor:pointer}
+.frontmatter-editor .actions{display:flex; justify-content:flex-end; gap:.5rem}
+
 /* Surface and editors */
 .surface{max-width:1100px; margin:1rem auto; padding:0 1rem}
 .editor{

--- a/index.html
+++ b/index.html
@@ -89,6 +89,22 @@
       <button id="btnExport" class="btn" title="Download Markdown" aria-label="Download">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Download</span>
       </button>
+      <div class="frontmatter-wrap">
+        <button id="btnFrontmatter" class="btn" title="Edit frontmatter" aria-expanded="false" aria-controls="frontmatterEditor" aria-label="Frontmatter">
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Frontmatter</span>
+        </button>
+        <div id="frontmatterEditor" class="frontmatter-editor" role="dialog" aria-modal="false" aria-label="Edit frontmatter">
+          <div class="row">
+            <input id="fmField" type="text" placeholder="Field">
+            <input id="fmValue" type="text" placeholder="Value">
+            <button id="fmAdd" type="button" class="add">Add</button>
+          </div>
+          <ul id="fmList"></ul>
+          <div class="actions">
+            <button id="fmClose" type="button" class="btn">Close</button>
+          </div>
+        </div>
+      </div>
       <button id="btnSource" class="btn" title="Toggle advanced mode  Ctrl or Cmd+/" aria-pressed="false" aria-label="Advanced">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
       </button>


### PR DESCRIPTION
## Summary
- add a Frontmatter dialog and parse YAML front matter on load/export
- handle frontmatter when toggling between source and WYSIWYG modes
- keep cursor position for Mermaid charts so Insert adds the diagram

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a83602f4508332906a902a48b4d1c6