### PR TITLE
Preserve blank lines and add spacing after tables/images

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -91,6 +91,11 @@
       }
     });
 
+    td.addRule('preserveBlank', {
+      filter: (node) => node.nodeName === 'P' && node.innerHTML.trim() === '',
+      replacement: () => '\n\n'
+    });
+
     mermaid.initialize({ startOnLoad: false });
   } catch (err) {
     console.error(err);
@@ -214,15 +219,15 @@
     } else {
       editor.appendChild(table);
     }
-    // place caret into first cell
-    const first = table.querySelector('td');
-    if (first) {
-      const sel = window.getSelection();
-      const nr = document.createRange();
-      nr.selectNodeContents(first);
-      nr.collapse(true);
-      sel.removeAllRanges(); sel.addRange(nr);
-    }
+    const blank = document.createElement('p');
+    blank.innerHTML = '<br>';
+    table.insertAdjacentElement('afterend', blank);
+    const sel = window.getSelection();
+    const nr = document.createRange();
+    nr.selectNodeContents(blank);
+    nr.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(nr);
   }
 
   function insertMermaidChart(definition) {
@@ -595,7 +600,25 @@
       const dataUrl = reader.result;
       const alt = prompt('Alt text', '') || '';
       const safeAlt = alt.replace(/"/g, '&quot;');
-      document.execCommand('insertHTML', false, `<img src="${dataUrl}" alt="${safeAlt}">`);
+      const img = document.createElement('img');
+      img.src = dataUrl;
+      img.alt = safeAlt;
+      const rng = getSelectionRange();
+      if (rng) {
+        rng.deleteContents();
+        rng.insertNode(img);
+      } else {
+        editor.appendChild(img);
+      }
+      const blank = document.createElement('p');
+      blank.innerHTML = '<br>';
+      img.insertAdjacentElement('afterend', blank);
+      const sel = window.getSelection();
+      const nr = document.createRange();
+      nr.selectNodeContents(blank);
+      nr.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(nr);
       savedRange = null;
     };
     reader.readAsDataURL(file);

--- a/assets/style.css
+++ b/assets/style.css
@@ -157,6 +157,7 @@ body{
 .editor h3{font-size:1.3rem}
 .editor h4{font-size:1.15rem}
 .editor p{margin:.6em 0}
+.editor p:empty{margin:0; padding:.6em 0}
 .editor strong{font-weight:700}
 .editor em{font-style:italic}
 .editor s{opacity:.9; text-decoration: line-through}


### PR DESCRIPTION
## Summary
- keep empty paragraphs visible to avoid blank line collapse
- insert blank paragraphs after tables and images so editing can continue after them
- preserve blank lines when exporting markdown

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a83df3379083328345335bb580f4aa