### PR TITLE
Ensure tables span full width with wider last column

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -164,12 +164,14 @@ body{
 .editor a{color:var(--accent)}
 .editor ul, .editor ol{padding-left:1.4rem}
 .editor table{
-  border-collapse:collapse; width:max(60%, 520px); max-width:100%; margin:1rem 0;
+  border-collapse:collapse; width:100%; margin:1rem 0;
   border:1px solid var(--edge); background:var(--surface)
 }
 .editor th, .editor td{
   border:1px solid var(--edge); padding:.5rem .6rem; vertical-align:top
 }
+.editor th:not(:last-child), .editor td:not(:last-child){white-space:nowrap; width:1%}
+.editor th:last-child, .editor td:last-child{width:100%}
 .editor tbody tr:nth-child(odd){background:var(--table-odd)}
 .editor td:focus{outline:2px solid var(--accent-2); outline-offset:-2px}
 


### PR DESCRIPTION
## Summary
- Make editor tables span full width of the editor surface
- Give the final column priority width so preceding columns stay narrow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8451ed62883329b9a2256ff51e899