### PR TITLE
Ensure tables span full width

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -163,16 +163,16 @@ body{
 .editor s{opacity:.9; text-decoration: line-through}
 .editor a{color:var(--accent)}
 .editor ul, .editor ol{padding-left:1.4rem}
-.editor table{
+table{
   border-collapse:collapse; width:100%; margin:1rem 0;
   border:1px solid var(--edge); background:var(--surface)
 }
-.editor th, .editor td{
+th, td{
   border:1px solid var(--edge); padding:.5rem .6rem; vertical-align:top
 }
-.editor th:not(:last-child), .editor td:not(:last-child){white-space:nowrap; width:1%}
-.editor th:last-child, .editor td:last-child{width:100%}
-.editor tbody tr:nth-child(odd){background:var(--table-odd)}
+th:not(:last-child), td:not(:last-child){white-space:nowrap; width:1%}
+th:last-child, td:last-child{width:100%}
+tbody tr:nth-child(odd){background:var(--table-odd)}
 .editor td:focus{outline:2px solid var(--accent-2); outline-offset:-2px}
 
 /* Headings block badge when toggled via keyboard hint */


### PR DESCRIPTION
## Summary
- Apply table styling globally so rendered tables stretch to the container edges
- Allocate remaining space to the last table column for smarter width distribution

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8476a73e48332930c725658f8aa06