### PR TITLE
Refactor find dialog into dropdown

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -44,9 +44,8 @@
   const fmAdd = $('#fmAdd');
   const fmList = $('#fmList');
   const fmClose = $('#fmClose');
-  const findWrap = $('.find-wrap');
+  const findWrap = $('#findWrap');
   const btnFind = $('#btnFind');
-  const findDialog = $('#findDialog');
   const findInput = $('#findInput');
   const replaceInput = $('#replaceInput');
   const findCase = $('#findCase');
@@ -571,17 +570,13 @@
   fmClose.addEventListener('click', closeFrontmatter);
 
   let lastFindIndex = 0;
-  function openFind(){
-    findDialog.classList.add('open');
-    btnFind.setAttribute('aria-expanded','true');
-    findInput.focus();
-  }
-  function closeFind(){
-    findDialog.classList.remove('open');
-    btnFind.setAttribute('aria-expanded','false');
-    lastFindIndex = 0;
-  }
-  function escapeRegExp(str){ return str.replace(/[.*+?^${}()|[\]\]/g, '\$&'); }
+  findWrap.addEventListener('toggle', () => {
+    const isOpen = findWrap.open;
+    btnFind.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    if (isOpen) findInput.focus(); else lastFindIndex = 0;
+  });
+  function closeFind(){ findWrap.open = false; }
+  function escapeRegExp(str){ return str.replace(/[.*+?^${}()|[\]\\]/g, '\$&'); }
   function selectTextInEditor(start, length){
     const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT, null);
     let pos = 0, node;
@@ -655,7 +650,6 @@
     }
     lastFindIndex = 0;
   }
-  btnFind.addEventListener('click', (e) => { e.stopPropagation(); if (findDialog.classList.contains('open')) closeFind(); else openFind(); });
   findClose.addEventListener('click', closeFind);
   findNextBtn.addEventListener('click', findNext);
   replaceBtn.addEventListener('click', replaceCurrent);
@@ -751,7 +745,7 @@
     else if (k === '/'){ e.preventDefault(); toggleSource(); }
     else if (k === 'd'){ e.preventDefault(); toggleTheme(); }
     else if (k === 's'){ e.preventDefault(); exportMarkdown(); }
-    else if (k === 'f'){ e.preventDefault(); if (findDialog.classList.contains('open')) closeFind(); else openFind(); }
+    else if (k === 'f'){ e.preventDefault(); findWrap.open = !findWrap.open; }
   });
 
   // Basic startup

--- a/assets/style.css
+++ b/assets/style.css
@@ -118,11 +118,13 @@ body{
 
 /* Find/replace */
 .find-wrap{position:relative}
+.find-wrap summary{list-style:none}
+.find-wrap summary::-webkit-details-marker{display:none}
 .find-dialog{
   position:absolute; top:2.6rem; left:0; border:1px solid var(--edge); background:var(--surface);
-  border-radius:.5rem; box-shadow:0 6px 24px rgba(0,0,0,.12); padding:.5rem; display:none; z-index:50; width:260px;
+  border-radius:.5rem; box-shadow:0 6px 24px rgba(0,0,0,.12); padding:.5rem; z-index:50; width:260px;
 }
-.find-dialog.open{display:block}
+.find-wrap:not([open]) .find-dialog{display:none}
 .find-dialog .row{display:flex; gap:.5rem; margin-bottom:.5rem; align-items:center}
 .find-dialog .row input{flex:1; padding:.3rem .4rem; border:1px solid var(--edge); border-radius:.3rem}
 .find-dialog .actions{display:flex; justify-content:flex-end; gap:.5rem}

--- a/index.html
+++ b/index.html
@@ -89,11 +89,11 @@
       <button id="btnExport" class="btn" title="Download Markdown" aria-label="Download">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Download</span>
       </button>
-      <div class="find-wrap">
-        <button id="btnFind" class="btn" title="Find and replace  Ctrl or Cmd+F" aria-expanded="false" aria-controls="findDialog" aria-label="Find">
+      <details id="findWrap" class="find-wrap">
+        <summary id="btnFind" class="btn" title="Find and replace  Ctrl or Cmd+F" aria-expanded="false" aria-controls="findDialog" aria-label="Find">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#search"/></svg><span>Find</span>
-        </button>
-        <div id="findDialog" class="find-dialog" role="dialog" aria-modal="false" aria-label="Find and replace">
+        </summary>
+        <div id="findDialog" class="find-dialog" role="dialog" aria-label="Find and replace">
           <div class="row">
             <input id="findInput" type="text" placeholder="Find">
             <input id="replaceInput" type="text" placeholder="Replace">
@@ -108,7 +108,7 @@
             <button id="findClose" type="button" class="btn">Close</button>
           </div>
         </div>
-      </div>
+      </details>
       <div class="frontmatter-wrap">
         <button id="btnFrontmatter" class="btn" title="Edit frontmatter" aria-expanded="false" aria-controls="frontmatterEditor" aria-label="Frontmatter">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Frontmatter</span>


### PR DESCRIPTION
## Summary
- Convert find/replace panel into a `<details>` dropdown so toolbar only shows a Find button
- Simplify CSS and JS to use the details element's open state for toggling

## Testing
- `node --check assets/app.js`
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a847df6cbc8332a4ad1cf0055c97bd