### PR TITLE
Improve find/replace dialog and limit table width

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -440,6 +440,9 @@
   buildTableGrid();
 
   function openPicker() {
+    closeChartBuilder();
+    closeFrontmatter();
+    closeFind();
     tablePicker.classList.add('open');
     btnTable.setAttribute('aria-expanded','true');
     tableHint.textContent = '0 × 0';
@@ -488,6 +491,9 @@
     updateChartPreview();
   }
   function openChartBuilder(){
+    closePicker();
+    closeFrontmatter();
+    closeFind();
     chartBuilder.classList.add('open');
     btnChart.setAttribute('aria-expanded','true');
     resetChartBuilder();
@@ -551,9 +557,13 @@
     });
   }
   function openFrontmatter(){
+    closePicker();
+    closeChartBuilder();
+    closeFind();
     renderFrontmatterList();
     fmEditor.classList.add('open');
     btnFrontmatter.setAttribute('aria-expanded','true');
+    fmField.focus();
   }
   function closeFrontmatter(){
     fmEditor.classList.remove('open');
@@ -572,6 +582,9 @@
 
   let lastFindIndex = 0;
   function openFind(){
+    closePicker();
+    closeChartBuilder();
+    closeFrontmatter();
     findDialog.classList.add('open');
     btnFind.setAttribute('aria-expanded','true');
     findInput.focus();
@@ -657,6 +670,7 @@
   }
   btnFind.addEventListener('click', (e) => { e.stopPropagation(); if (findDialog.classList.contains('open')) closeFind(); else openFind(); });
   findClose.addEventListener('click', closeFind);
+  findDialog.addEventListener('click', e => e.stopPropagation());
   findNextBtn.addEventListener('click', findNext);
   replaceBtn.addEventListener('click', replaceCurrent);
   replaceAllBtn.addEventListener('click', replaceAll);

--- a/assets/style.css
+++ b/assets/style.css
@@ -175,14 +175,12 @@ body{
 .editor a{color:var(--accent)}
 .editor ul, .editor ol{padding-left:1.4rem}
 .editor table{
-  border-collapse:collapse; width:100%; margin:1rem 0;
-  border:1px solid var(--edge); background:var(--surface)
+  border-collapse:collapse; width:100%; max-width:100%; margin:1rem 0;
+  border:1px solid var(--edge); background:var(--surface); table-layout:fixed
 }
 .editor th, .editor td{
-  border:1px solid var(--edge); padding:.5rem .6rem; vertical-align:top
+  border:1px solid var(--edge); padding:.5rem .6rem; vertical-align:top; word-break:break-word
 }
-.editor th:not(:last-child), .editor td:not(:last-child){white-space:nowrap; width:1%}
-.editor th:last-child, .editor td:last-child{width:100%}
 .editor tbody tr:nth-child(odd){background:var(--table-odd)}
 .editor td:focus{outline:2px solid var(--accent-2); outline-offset:-2px}
 


### PR DESCRIPTION
## Summary
- Ensure opening any toolbar popup closes others to prevent conflicts
- Keep find dialog open on internal actions and stop event bubbling
- Limit table elements to editor width with fixed layout and word wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a84ccc310083328ea0d6096115f6d9