### PR TITLE
fix: pin ribbon and preserve cursor

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -18,6 +18,7 @@
   const btnUndo = $('#btnUndo');
   const btnImage = $('#btnImage');
   const btnLink = $('#btnLink');
+  const ribbon = $('.ribbon');
   const tableWrap = $('.table-wrap');
   const tablePicker = $('#tablePicker');
   const tableGrid = tablePicker.querySelector('.grid');
@@ -54,6 +55,11 @@
   const replaceBtn = $('#replaceOne');
   const replaceAllBtn = $('#replaceAll');
   const findClose = $('#findClose');
+
+  // Prevent toolbar clicks from moving editor focus
+  ribbon.addEventListener('mousedown', (e) => {
+    if (e.target.closest('button')) e.preventDefault();
+  });
 
   function toast(msg, cls = '') {
     const el = document.createElement('div');

--- a/assets/style.css
+++ b/assets/style.css
@@ -42,6 +42,7 @@
 html,body{height:100%}
 body{
   margin:0;
+  padding-top:3.5rem;
   background:var(--bg);
   color:var(--fg);
   font:16px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -51,7 +52,8 @@ body{
 
 /* Ribbon toolbar */
 .ribbon{
-  position:sticky; top:0; z-index:20;
+  position:fixed;
+  top:0; left:0; right:0; z-index:20;
   border-bottom:1px solid var(--edge);
   background:linear-gradient(to bottom, var(--surface), color-mix(in srgb, var(--surface) 90%, var(--edge) 10%));
 }


### PR DESCRIPTION
## Summary
- Keep toolbar pinned by switching ribbon to fixed positioning and offsetting page content
- Prevent toolbar clicks from stealing focus so the cursor remains in place while using controls

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a84e4a44948332967a54721c3bc05d