### PR TITLE
Fix regex escaping breaking toolbar features

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -594,7 +594,7 @@
     btnFind.setAttribute('aria-expanded','false');
     lastFindIndex = 0;
   }
-  function escapeRegExp(str){ return str.replace(/[.*+?^${}()|[\]\]/g, '\$&'); }
+  function escapeRegExp(str){ return str.replace(/[.*+?^${}()|[\]\\]/g, '\$&'); }
   function selectTextInEditor(start, length){
     const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT, null);
     let pos = 0, node;


### PR DESCRIPTION
## Summary
- Correct bad regular expression in `escapeRegExp` that prevented the editor script from running, restoring all toolbar actions.

## Testing
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a84ea2b1f4833280d90bd920128a51