### PR TITLE
Ensure toolbar buttons preserve editor focus

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -46,10 +46,12 @@
   const fmList = $('#fmList');
   const fmClose = $('#fmClose');
 
-  // Prevent toolbar clicks from moving editor focus
-  ribbon.addEventListener('mousedown', (e) => {
+  // Prevent toolbar clicks from moving editor focus across input types
+  function keepEditorFocus(e) {
     if (e.target.closest('button')) e.preventDefault();
-  });
+  }
+  ribbon.addEventListener('pointerdown', keepEditorFocus);
+  ribbon.addEventListener('mousedown', keepEditorFocus);
 
   function toast(msg, cls = '') {
     const el = document.createElement('div');


### PR DESCRIPTION
## Summary
- keep editor selection when toolbar buttons are pressed by preventing pointerdown default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a851e284a4833287c11e789ec9f02c