### PR TITLE
Fix frontmatter popdown overflow

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -121,7 +121,7 @@ body{
 /* Frontmatter editor */
 .frontmatter-wrap{position:relative}
 .frontmatter-editor{
-  position:absolute; top:2.6rem; left:0; border:1px solid var(--edge); background:var(--surface);
+  position:absolute; top:2.6rem; right:0; border:1px solid var(--edge); background:var(--surface);
   border-radius:.5rem; box-shadow:0 6px 24px rgba(0,0,0,.12); padding:.5rem; display:none; z-index:50; width:260px;
 }
 .frontmatter-editor.open{display:block}


### PR DESCRIPTION
## Summary
- anchor frontmatter editor popup to the right so it no longer spills off-screen

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85344ce0883328e37319a66f293c4