### PR TITLE
Add node connection selection for Mermaid chart builder

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -112,7 +112,10 @@ body{
 .chart-builder.open{display:block}
 .chart-builder .row{display:flex; align-items:center; gap:.5rem; margin-bottom:.5rem}
 .chart-builder .nodes{display:flex; flex-direction:column; gap:.25rem; margin-bottom:.5rem}
-.chart-builder .nodes input{padding:.3rem .4rem; border:1px solid var(--edge); border-radius:.3rem}
+.chart-builder .node{display:flex; align-items:center; gap:.25rem}
+.chart-builder .node input{flex:1}
+.chart-builder .nodes input,.chart-builder .nodes select{padding:.3rem .4rem; border:1px solid var(--edge); border-radius:.3rem}
+.chart-builder .nodes select{width:5rem}
 .chart-builder .add{width:100%; padding:.3rem; margin-bottom:.5rem; border:1px solid var(--edge); background:#fff0; border-radius:.4rem; cursor:pointer}
 .chart-builder .add:hover{background:var(--edge)}
 .chart-builder .preview{border:1px solid var(--edge); border-radius:.3rem; padding:.4rem; min-height:60px; margin-bottom:.5rem}

--- a/index.html
+++ b/index.html
@@ -65,6 +65,12 @@
             </select>
           </div>
           <div id="chartNodes" class="nodes"></div>
+          <template id="chartNodeTpl">
+            <div class="node">
+              <input type="text">
+              <select></select>
+            </div>
+          </template>
           <button id="chartAdd" class="add" type="button">Add step</button>
           <div id="chartPreview" class="preview"></div>
           <div class="actions">


### PR DESCRIPTION
## Summary
- allow chart nodes to include a select for connections
- render custom edges from node selections when building Mermaid code
- style node rows and selectors to keep chart builder compact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda6ab06483328fff08ef59196d2d