### PR TITLE
Allow multiple chart connections

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -524,16 +524,16 @@
     rows.forEach((row,i) => { row.dataset.id = letters[i]; });
     rows.forEach((row,i) => {
       const select = row.querySelector('select');
-      const prev = select.value;
-      select.innerHTML = '<option value="">None</option>';
+      const prev = [...select.selectedOptions].map(o => o.value);
+      select.innerHTML = '';
       rows.forEach((r,j) => {
         if (i === j) return;
         const opt = document.createElement('option');
         opt.value = r.dataset.id;
         opt.textContent = r.dataset.id;
+        if (prev.includes(opt.value)) opt.selected = true;
         select.appendChild(opt);
       });
-      if ([...select.options].some(o => o.value === prev)) select.value = prev;
     });
   }
 
@@ -553,8 +553,11 @@
     let code = `graph ${dir}\n`;
     nodes.forEach(n => { code += `${n.id}["${n.label.replace(/"/g,'\\"')}"]\n`; });
     nodes.forEach(n => {
-      const to = n.row.querySelector('select').value;
-      if (to && active.has(to)) code += `${n.id}-->${to}\n`;
+      const select = n.row.querySelector('select');
+      [...select.selectedOptions].forEach(opt => {
+        const to = opt.value;
+        if (to && active.has(to)) code += `${n.id}-->${to}\n`;
+      });
     });
     return code;
   }

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
           <template id="chartNodeTpl">
             <div class="node">
               <input type="text">
-              <select></select>
+              <select multiple size="3"></select>
             </div>
           </template>
           <button id="chartAdd" class="add" type="button">Add step</button>


### PR DESCRIPTION
## Summary
- Switch chart node target selector to multi-select to allow multiple outbound links
- Preserve selections and build edges for all selected targets in chart preview

## Testing
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aee5e68fc4833285a02c95f3cbd60d