### PR TITLE
Support mermaid charts in source mode

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -107,10 +107,8 @@
 
     if (window.mermaid) {
       mermaid.initialize({ startOnLoad: false });
-    } else {
-      btnChart.disabled = true;
-      btnChart.setAttribute('aria-disabled', 'true');
     }
+    updateChartButtonState();
   } catch (err) {
     console.error(err);
     toast('Required libraries failed to load', 'warn');
@@ -245,7 +243,15 @@
   }
 
   function insertMermaidChart(definition) {
-    if (mode !== 'wysiwyg' || !definition) return;
+    if (!definition) return;
+    if (mode === 'source') {
+      const block = `\n\u0060\u0060\u0060mermaid\n${definition}\n\u0060\u0060\u0060\n`;
+      const { selectionStart, selectionEnd } = srcTA;
+      srcTA.setRangeText(block, selectionStart, selectionEnd, 'end');
+      srcTA.focus();
+      return;
+    }
+    if (mode !== 'wysiwyg') return;
     if (savedRange) {
       const sel = window.getSelection();
       sel.removeAllRanges();
@@ -402,6 +408,7 @@
   // Advanced toggle
   function toggleSource(forceToSource) {
     const toSource = typeof forceToSource === 'boolean' ? forceToSource : (mode === 'wysiwyg');
+    closeChartBuilder();
     if (toSource) {
       // html -> md -> textarea
       normaliseInlineTags();
@@ -425,6 +432,14 @@
       btnSource.setAttribute('aria-pressed', 'false');
       mode = 'wysiwyg';
     }
+    updateChartButtonState();
+  }
+
+  function updateChartButtonState() {
+    const disabled = (mode !== 'wysiwyg') || !window.mermaid;
+    btnChart.disabled = disabled;
+    btnChart.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+    if (disabled) closeChartBuilder();
   }
 
   // Table picker build
@@ -564,9 +579,10 @@
     chartPreview.innerHTML = `<div class="mermaid">${code}</div>`;
     try{ mermaid.init(undefined, chartPreview.querySelector('.mermaid')); }catch(_){ }
   }
-  btnChart.addEventListener('mousedown', () => { if (mode !== 'wysiwyg') return; savedRange = getSelectionRange(); });
+  btnChart.addEventListener('mousedown', () => { if (btnChart.disabled) return; savedRange = getSelectionRange(); });
   btnChart.addEventListener('click', (e) => {
     e.stopPropagation();
+    if (btnChart.disabled) return;
     if (chartBuilder.classList.contains('open')) closeChartBuilder(); else openChartBuilder();
   });
   chartAdd.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Insert mermaid fenced blocks into the source editor when chart builder is used in source mode.
- Disable the chart button outside WYSIWYG mode and keep its state synced when switching modes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee5e602b4833292afb5f8e6c8cd5e