### PR TITLE
Fix frontmatter editor layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -128,9 +128,31 @@ body{
   border-radius:.5rem; box-shadow:0 6px 24px rgba(0,0,0,.12); padding:.5rem; display:none; z-index:50; width:260px;
 }
 .frontmatter-editor.open{display:block}
-.frontmatter-editor .row{display:flex; gap:.5rem; margin-bottom:.5rem}
-.frontmatter-editor .row input{flex:1; padding:.3rem .4rem; border:1px solid var(--edge); border-radius:.3rem}
-.frontmatter-editor .row .add{padding:.3rem .5rem; border:1px solid var(--edge); background:#fff0; border-radius:.3rem; cursor:pointer}
+.frontmatter-editor .row{
+  display:grid;
+  grid-template-columns:1fr auto;
+  grid-template-rows:auto auto;
+  gap:.5rem;
+  margin-bottom:.5rem
+}
+.frontmatter-editor .row input{
+  padding:.3rem .4rem;
+  border:1px solid var(--edge);
+  border-radius:.3rem;
+  width:100%
+}
+.frontmatter-editor .row #fmField{grid-column:1; grid-row:1}
+.frontmatter-editor .row #fmValue{grid-column:1; grid-row:2}
+.frontmatter-editor .row .add{
+  grid-column:2;
+  grid-row:1/3;
+  align-self:stretch;
+  padding:.3rem .5rem;
+  border:1px solid var(--edge);
+  background:#fff0;
+  border-radius:.3rem;
+  cursor:pointer
+}
 .frontmatter-editor .row .add:hover{background:var(--edge)}
 .frontmatter-editor ul{list-style:none; padding:0; margin:0 0 .5rem 0}
 .frontmatter-editor li{display:flex; justify-content:space-between; align-items:center; margin-bottom:.25rem}


### PR DESCRIPTION
## Summary
- prevent frontmatter value overflow by switching input row to grid layout
- stack value field under the field input and stretch Add button across both rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee8b6222c8332810696bd864b7c2b