### PR TITLE
Add status bar showing word and character counts

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -46,6 +46,7 @@
   const fmAdd = $('#fmAdd');
   const fmList = $('#fmList');
   const fmClose = $('#fmClose');
+  const statusBar = $('#statusBar');
 
   // Prevent toolbar clicks from moving editor focus across input types
   function keepEditorFocus(e) {
@@ -164,6 +165,15 @@
 
   function frontmatterToYAML(obj) {
     return Object.entries(obj).map(([k, v]) => `${k}: ${v}`).join('\n');
+  }
+
+  function updateStatusBar() {
+    const mdText = mode === 'source'
+      ? (srcTA.value || '')
+      : td.turndown(editor.innerHTML);
+    const words = mdText.trim() ? mdText.trim().split(/\s+/).length : 0;
+    const chars = mdText.length;
+    statusBar.textContent = `${words} words, ${chars} chars`;
   }
 
   const BLOCKS = new Set(['P','DIV','H1','H2','H3','H4','H5','H6','LI','TD','TH']);
@@ -447,6 +457,7 @@
       btnSource.setAttribute('aria-pressed', 'false');
       mode = 'wysiwyg';
     }
+    updateStatusBar();
     updateChartButtonState();
   }
 
@@ -750,8 +761,12 @@
   });
 
   // Basic startup
-  editor.addEventListener('input', () => { /* keep DOM tidy */ });
+  editor.addEventListener('input', () => {
+    /* keep DOM tidy */
+    updateStatusBar();
+  });
   editor.addEventListener('blur', () => normaliseInlineTags());
+  srcTA.addEventListener('input', updateStatusBar);
 
   // Public sample if user opens without a file
   const sample = [
@@ -774,5 +789,6 @@
     'Some **bold**, some _italic_, some ~~strike~~, and a [link](https://example.org).'
   ].join('\n');
   renderMarkdownToEditor(sample);
+  updateStatusBar();
 
 })();

--- a/assets/style.css
+++ b/assets/style.css
@@ -262,6 +262,14 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
   font-size:.8rem;
 }
 
+#statusBar{
+  position:fixed;
+  bottom:.5rem;
+  right:1rem;
+  font-size:.8rem;
+  color:var(--muted);
+}
+
 @media (min-width:900px){
   body:not(.shortcuts-collapsed) #main{margin-right:220px}
 }

--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
       <div id="editor" class="editor" contenteditable="true" role="textbox" aria-multiline="true" spellcheck="true"></div>
       <textarea id="source" class="source" aria-label="Markdown source" spellcheck="false"></textarea>
     </section>
+    <div id="statusBar"></div>
   </main>
 
   <aside id="shortcuts" class="shortcuts" aria-label="Keyboard shortcuts">


### PR DESCRIPTION
## Summary
- Add status bar element to display live word and character counts
- Compute counts from current Markdown on editor and source updates
- Style status bar for small, muted display fixed at bottom-right

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed429fb88332976ed815e8cb6d44