### PR TITLE
Rebrand QuietMark to Scriptor

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,4 @@
-// QuietMark editor
+// Scriptor editor
 (() => {
   const $ = sel => document.querySelector(sel);
   const $$ = sel => Array.from(document.querySelectorAll(sel));
@@ -755,7 +755,7 @@
 
   // Public sample if user opens without a file
   const sample = [
-    '# QuietMark',
+    '# Scriptor',
     '',
     'Edit like normal text; export to Markdown when ready.',
     '',

--- a/assets/style.css
+++ b/assets/style.css
@@ -50,6 +50,19 @@ body{
   text-rendering: optimizeLegibility;
 }
 
+.visually-hidden{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0 0 0 0);
+  clip-path:inset(50%);
+  white-space:nowrap;
+  border:0;
+}
+
 /* Ribbon toolbar */
 .ribbon{
   position:fixed;

--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>QuietMark — Markdown editor</title>
+  <title>Scriptor — Markdown editor</title>
   <link rel="stylesheet" href="assets/style.css">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 4h16v16H4zM6 7h12v2H6zm0 4h8v2H6zm0 4h5v2H6z'/%3E%3C/svg%3E">
 </head>
 <body>
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">
+    <h1 class="visually-hidden">Scriptor</h1>
     <nav role="toolbar" aria-label="Formatting">
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>
       <input id="imgInput" type="file" accept="image/*" hidden>


### PR DESCRIPTION
## Summary
- Update HTML title and JavaScript samples from QuietMark to Scriptor
- Add a visually hidden Scriptor heading for branding
- Introduce reusable `.visually-hidden` class in stylesheet

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef685e874833290d5469a72aa1f06