### PR TITLE
Add Scriptor favicon and meta description

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M44 8H24a12 12 0 1 0 0 24h16a12 12 0 1 1 0 24H20" fill="none" stroke="#000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,14 @@
 <!doctype html>
 <html lang="en-GB" data-theme="light">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>QuietMark — Markdown editor</title>
-  <link rel="stylesheet" href="assets/style.css">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 4h16v16H4zM6 7h12v2H6zm0 4h8v2H6zm0 4h5v2H6z'/%3E%3C/svg%3E">
-</head>
-<body>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Scriptor — Markdown editor">
+    <title>QuietMark — Markdown editor</title>
+    <link rel="stylesheet" href="assets/style.css">
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  </head>
+  <body>
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">
     <nav role="toolbar" aria-label="Formatting">
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>


### PR DESCRIPTION
## Summary
- Replace placeholder square favicon with new Scriptor-themed SVG icon
- Strengthen metadata with description meta tag

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aef68d9588833293ed18680e66ffc9