### PR TITLE
Add status bar displaying word and character counts

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -46,6 +46,7 @@
   const fmAdd = $('#fmAdd');
   const fmList = $('#fmList');
   const fmClose = $('#fmClose');
+  const statusBar = $('#statusBar');
 
   // Prevent toolbar clicks from moving editor focus across input types
   function keepEditorFocus(e) {
@@ -191,6 +192,9 @@
   function handleInput() {
     const mdText = getCurrentMarkdown();
     saveDraft(mdText);
+    const words = mdText.trim().split(/\s+/).filter(Boolean).length;
+    const chars = mdText.length;
+    statusBar.textContent = `${words} words • ${chars} chars`;
   }
 
   const BLOCKS = new Set(['P','DIV','H1','H2','H3','H4','H5','H6','LI','TD','TH']);
@@ -818,6 +822,8 @@
     lastSavedMd = sample;
     saveDraft(sample);
   }
+
+  handleInput();
 
   window.addEventListener('beforeunload', (e) => {
     if (dirty) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -190,6 +190,15 @@ body{
 #dropZone.dragover .editor{border-color:var(--accent)}
 #dropZone.dragover .editor:before{content:"Release to load file"}
 
+#statusBar{
+  max-width:1100px;
+  margin:.5rem auto 0;
+  padding:0 1rem;
+  text-align:right;
+  font-size:.8rem;
+  color:var(--muted);
+}
+
 /* Content styling */
 .editor h1,.editor h2,.editor h3,.editor h4{line-height:1.25; margin:1.2em 0 .6em}
 .editor h1{font-size:1.9rem}

--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
       <div id="editor" class="editor" contenteditable="true" role="textbox" aria-multiline="true" spellcheck="true"></div>
       <textarea id="source" class="source" aria-label="Markdown source" spellcheck="false"></textarea>
     </section>
+    <div id="statusBar"></div>
   </main>
 
   <aside id="shortcuts" class="shortcuts" aria-label="Keyboard shortcuts">


### PR DESCRIPTION
## Summary
- Add status bar element to main area for live document metrics
- Compute and display word and character counts on editor input
- Style status bar with small muted text at the bottom-right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af023b37bc83329fdaf41720f431d0