### PR TITLE
Add Scriptor favicon and meta description

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#000"/>
+  <text x="12" y="12" dominant-baseline="middle" text-anchor="middle" font-family="monospace" font-size="14" fill="#fff">S</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Scriptor — Markdown editor">
   <title>Scriptor — Markdown editor</title>
   <link rel="stylesheet" href="assets/style.css">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 4h16v16H4zM6 7h12v2H6zm0 4h8v2H6zm0 4h5v2H6z'/%3E%3C/svg%3E">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
 </head>
 <body>
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">


### PR DESCRIPTION
## Summary
- Use new S-themed SVG favicon for clearer branding
- Add meta description to strengthen search presence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af0241e7d08332a32900cfa0f509bc