### PR TITLE
feat: expand sample with advanced markdown

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -810,7 +810,27 @@
     '| Apples | 3 |',
     '| Pears | 5 |',
     '',
-    'Some **bold**, some _italic_, some ~~strike~~, and a [link](https://example.org).'
+    'Some **bold**, some _italic_, some ~~strike~~, and a [link](https://example.org).',
+    '',
+    '```mermaid',
+    'graph TD',
+    '  Start --> Stop',
+    '```',
+    '',
+    '```js',
+    'console.log("Hello, world!");',
+    '```',
+    '',
+    '> A wise quote.',
+    '',
+    '---',
+    '',
+    '- [ ] Task one',
+    '- [x] Task two',
+    '',
+    'Inline code: `const x = 42;`',
+    '',
+    '![Placeholder image](https://via.placeholder.com/150)'
   ].join('\n');
   const savedDraft = (() => { try { return localStorage.getItem(DRAFT_KEY); } catch (_) { return null; } })();
   if (savedDraft) {


### PR DESCRIPTION
## Summary
- showcase Mermaid diagram example in starter sample
- add code block, blockquote, tasks, inline code and image demonstrations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1d1889d48332bda4895d2a9c34d9