### PR TITLE
Enable Ctrl/Cmd-click opening of links in editor

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -457,6 +457,24 @@
     if (window.mermaid) mermaid.init(undefined, mer);
   });
 
+  editor.addEventListener('click', (e) => {
+    if (e.target.tagName === 'A' && (e.ctrlKey || e.metaKey)) {
+      window.open(e.target.href, '_blank');
+      e.preventDefault();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.ctrlKey || e.metaKey) {
+      editor.querySelectorAll('a').forEach(a => a.classList.add('ctrl-link'));
+    }
+  });
+  document.addEventListener('keyup', (e) => {
+    if (!e.ctrlKey && !e.metaKey) {
+      editor.querySelectorAll('a').forEach(a => a.classList.remove('ctrl-link'));
+    }
+  });
+
   // Advanced toggle
   function toggleSource(forceToSource) {
     const toSource = typeof forceToSource === 'boolean' ? forceToSource : (mode === 'wysiwyg');

--- a/assets/style.css
+++ b/assets/style.css
@@ -211,6 +211,7 @@ body{
 .editor em{font-style:italic}
 .editor s{opacity:.9; text-decoration: line-through}
 .editor a{color:var(--accent)}
+.editor a.ctrl-link{text-decoration:underline}
 .editor ul, .editor ol{padding-left:1.4rem}
 .editor table{
   border-collapse:collapse; width:100%; max-width:100%; margin:1rem 0;


### PR DESCRIPTION
## Summary
- open links in the editor in a new tab when Ctrl or Cmd is held
- visually underline links while modifier key pressed for a cue

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02da78c4c833283e3b72a1c457608