### PR TITLE
Add export menu with Pandoc conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Scriptor
+
+## Exporting documents
+
+Scriptor now supports exporting documents in multiple formats. The export menu in the toolbar allows choosing **Markdown**, **PDF**, **DOCX**, or **HTML**.
+
+- Markdown is generated directly in the browser.
+- PDF, DOCX, and HTML rely on [Pandoc](https://pandoc.org/) for conversion. The frontend expects a backend endpoint at `/api/convert` that accepts JSON `{ markdown, format }` and returns the converted file as a binary response. Alternatively, a Pandoc WASM bundle can be used to provide the same API.
+
+Ensure that Pandoc is available on the server and that the `/api/convert` endpoint is implemented before enabling non-Markdown exports.

--- a/index.html
+++ b/index.html
@@ -94,9 +94,13 @@
       <button id="btnLoad" class="btn" title="Upload .md file" aria-label="Upload">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Upload</span>
       </button>
-      <button id="btnExport" class="btn" title="Download Markdown" aria-label="Download">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#export"/></svg><span>Download</span>
-      </button>
+      <select id="exportMenu" class="btn" title="Export document" aria-label="Export">
+        <option value="" selected disabled>Export…</option>
+        <option value="md">Markdown</option>
+        <option value="pdf">PDF</option>
+        <option value="docx">DOCX</option>
+        <option value="html">HTML</option>
+      </select>
       <div class="frontmatter-wrap">
         <button id="btnFrontmatter" class="btn" title="Edit frontmatter" aria-expanded="false" aria-controls="frontmatterEditor" aria-label="Frontmatter">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Frontmatter</span>
@@ -140,7 +144,7 @@
       <li><kbd>Ctrl</kbd> + <kbd>1</kbd>–<kbd>4</kbd> Headings</li>
       <li><kbd>Ctrl</kbd> + <kbd>/</kbd> Advanced mode</li>
       <li><kbd>Ctrl</kbd> + <kbd>D</kbd> Dark mode</li>
-      <li><kbd>Ctrl</kbd> + <kbd>S</kbd> Download</li>
+      <li><kbd>Ctrl</kbd> + <kbd>S</kbd> Export (Markdown)</li>
     </ul>
   </aside>
 


### PR DESCRIPTION
## Summary
- Replace single download button with export menu for Markdown, PDF, DOCX, and HTML
- Add exportDocument() with Pandoc-backed conversion for non-Markdown formats
- Document required Pandoc `/api/convert` endpoint

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02dafcc648332a4dc083ebbdabf2d