### PR TITLE
Add Pandoc conversion API and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ Scriptor now supports exporting documents in multiple formats. The export menu i
 - PDF, DOCX, and HTML rely on [Pandoc](https://pandoc.org/) for conversion. The frontend expects a backend endpoint at `/api/convert` that accepts JSON `{ markdown, format }` and returns the converted file as a binary response. Alternatively, a Pandoc WASM bundle can be used to provide the same API.
 
 Ensure that Pandoc is available on the server and that the `/api/convert` endpoint is implemented before enabling non-Markdown exports.
+
+## Deployment
+
+Serve `index.html` and the `assets/` directory as static files. Run the conversion server alongside the frontend so that `/api/convert` is reachable.
+
+```
+pip install flask  # only required for the Python server
+python server.py
+```
+
+The server accepts `POST /api/convert` with JSON `{ markdown, format }` and streams the converted file back using Pandoc. The frontend checks this endpoint at startup and only enables PDF, DOCX, and HTML exports when it responds.

--- a/assets/app.js
+++ b/assets/app.js
@@ -11,6 +11,11 @@
   const dropZone = $('#dropZone');
   const btnLoad = $('#btnLoad');
   const exportMenu = $('#exportMenu');
+  const backendFormats = ['pdf','docx','html'];
+  backendFormats.forEach(fmt => {
+    const opt = exportMenu.querySelector(`option[value="${fmt}"]`);
+    if (opt) opt.disabled = true;
+  });
   const btnSource = $('#btnSource');
   const btnBold = $('#btnBold');
   const btnItalic = $('#btnItalic');
@@ -398,6 +403,19 @@
     });
     if (!res.ok) throw new Error('Conversion failed');
     return res.blob();
+  }
+
+  async function checkConvertEndpoint() {
+    try {
+      const res = await fetch('/api/convert', { method: 'OPTIONS' });
+      if (!res.ok) throw new Error('Unavailable');
+      backendFormats.forEach(fmt => {
+        const opt = exportMenu.querySelector(`option[value="${fmt}"]`);
+        if (opt) opt.disabled = false;
+      });
+    } catch (err) {
+      console.warn('Conversion endpoint unavailable');
+    }
   }
 
   function setTheme(theme){
@@ -891,6 +909,7 @@
   }
 
   handleInput();
+  checkConvertEndpoint();
 
   window.addEventListener('beforeunload', (e) => {
     if (dirty) {

--- a/server.py
+++ b/server.py
@@ -1,0 +1,39 @@
+import subprocess
+from flask import Flask, request, Response, jsonify
+
+app = Flask(__name__)
+
+FORMAT_TO_MIME = {
+    'pdf': 'application/pdf',
+    'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'html': 'text/html',
+    'md': 'text/markdown'
+}
+
+@app.route('/api/convert', methods=['POST', 'OPTIONS'])
+def convert():
+    if request.method == 'OPTIONS':
+        return ('', 204)
+    data = request.get_json(force=True) or {}
+    markdown = data.get('markdown')
+    fmt = data.get('format')
+    if not markdown or not fmt:
+        return jsonify({'error': 'Missing markdown or format'}), 400
+    args = ['pandoc', '--from=markdown', f'--to={fmt}', '--output=-']
+    try:
+        proc = subprocess.run(
+            args,
+            input=markdown.encode('utf-8'),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False
+        )
+    except FileNotFoundError:
+        return jsonify({'error': 'Pandoc not installed'}), 500
+    if proc.returncode != 0:
+        return jsonify({'error': proc.stderr.decode('utf-8', errors='ignore')}), 500
+    mime = FORMAT_TO_MIME.get(fmt, 'application/octet-stream')
+    return Response(proc.stdout, mimetype=mime)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add Flask server exposing `/api/convert` that runs Pandoc and returns binary output
- disable export formats until the conversion endpoint responds
- document how to run the server alongside the static frontend

## Testing
- `python -m py_compile server.py`
- `curl -i -H 'Content-Type: application/json' -d '{"markdown":"# Test","format":"html"}' http://localhost:8000/api/convert | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b0355e8b0c83329c1acf6378c2396c