### PR TITLE
Add delayed tooltip behavior

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -53,6 +53,60 @@
   const fmClose = $('#fmClose');
   const statusBar = $('#statusBar');
 
+  // Tooltips
+  const tooltipDelay = 500;
+  let tooltipTimer = null;
+  let hideTooltipTimer = null;
+  let tooltipBox = null;
+  let tooltipOwner = null;
+
+  function initTooltips() {
+    $$('[title]').forEach(el => {
+      el.dataset.tip = el.getAttribute('title');
+      el.removeAttribute('title');
+      el.addEventListener('pointerenter', showTooltip);
+      el.addEventListener('pointerleave', hideTooltip);
+      el.addEventListener('focus', showTooltip);
+      el.addEventListener('blur', hideTooltip);
+    });
+  }
+
+  function showTooltip(e) {
+    const target = e.currentTarget;
+    clearTimeout(hideTooltipTimer);
+    const reveal = () => {
+      if (!tooltipBox) {
+        tooltipBox = document.createElement('div');
+        tooltipBox.className = 'tooltip';
+        document.body.appendChild(tooltipBox);
+      }
+      tooltipBox.textContent = target.dataset.tip;
+      const rect = target.getBoundingClientRect();
+      tooltipBox.style.left = window.scrollX + rect.left + rect.width / 2 + 'px';
+      tooltipBox.style.top = window.scrollY + rect.top + 'px';
+      tooltipBox.style.transform = 'translate(-50%, calc(-100% - 8px))';
+      tooltipBox.style.transition = tooltipOwner ? 'none' : '';
+      tooltipBox.classList.add('show');
+      tooltipOwner = target;
+    };
+    if (tooltipOwner) {
+      reveal();
+    } else {
+      tooltipTimer = setTimeout(reveal, tooltipDelay);
+    }
+  }
+
+  function hideTooltip() {
+    clearTimeout(tooltipTimer);
+    hideTooltipTimer = setTimeout(() => {
+      if (tooltipBox) tooltipBox.classList.remove('show');
+      if (tooltipBox) tooltipBox.style.transition = '';
+      tooltipOwner = null;
+    }, 100);
+  }
+
+  initTooltips();
+
   // Prevent toolbar clicks from moving editor focus across input types
   function keepEditorFocus(e) {
     if (e.target.closest('button')) e.preventDefault();

--- a/assets/style.css
+++ b/assets/style.css
@@ -94,6 +94,23 @@ body{
 .sep{width:1px; height:26px; background:var(--edge); margin:0 .25rem}
 .spacer{flex:1 1 auto}
 
+/* Tooltips */
+.tooltip{
+  position:absolute;
+  background:var(--surface);
+  color:var(--fg);
+  border:1px solid var(--edge);
+  border-radius:.25rem;
+  padding:.25rem .5rem;
+  font-size:.8rem;
+  box-shadow:0 2px 6px rgba(0,0,0,.15);
+  pointer-events:none;
+  opacity:0;
+  transition:opacity .15s ease;
+  z-index:100;
+}
+.tooltip.show{opacity:1}
+
 /* Table picker */
 .table-wrap{position:relative}
 .table-picker{


### PR DESCRIPTION
## Summary
- Introduce a custom tooltip system with an initial appearance delay.
- Show tooltips instantly without animation once one is open.
- Style tooltip component to match existing UI.

## Testing
- `node --check assets/app.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c83938dc8332bc362f36e8af8b12