### PR TITLE
Add explanatory comments across project

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,9 +1,11 @@
-// Scriptor editor
+// Core client-side logic for the Scriptor Markdown editor
 (() => {
+  // Convenience DOM helpers
   const $ = sel => document.querySelector(sel);
   const $$ = sel => Array.from(document.querySelectorAll(sel));
 
-  // Elements
+  // Grab all of the frequently used elements up front so the rest of the
+  // code can refer to them without repeatedly querying the DOM.
   const editor = $('#editor');
   const srcTA = $('#source');
   const fileInput = $('#fileInput');
@@ -11,6 +13,8 @@
   const dropZone = $('#dropZone');
   const btnLoad = $('#btnLoad');
   const exportMenu = $('#exportMenu');
+  // Only the backend understands these formats; the options get disabled until
+  // the server confirms support.
   const backendFormats = ['pdf','docx','html'];
   backendFormats.forEach(fmt => {
     const opt = exportMenu.querySelector(`option[value="${fmt}"]`);
@@ -53,7 +57,9 @@
   const fmClose = $('#fmClose');
   const statusBar = $('#statusBar');
 
-  // Tooltips
+  // ---------------------------------------------------------------------------
+  // Tooltip handling
+  // ---------------------------------------------------------------------------
   const tooltipDelay = 500;
   let tooltipTimer = null;
   let hideTooltipTimer = null;
@@ -117,22 +123,29 @@
   ribbon.addEventListener('pointerdown', keepEditorFocus);
   ribbon.addEventListener('mousedown', keepEditorFocus);
 
+  // Show a temporary message in the bottom-right corner
   function toast(msg, cls = '') {
     const el = document.createElement('div');
     el.className = 'toast ' + cls;
     el.textContent = msg;
     toasts.appendChild(el);
-    setTimeout(() => { el.classList.add('fade'); el.addEventListener('transitionend', () => el.remove(), { once:true }); }, 2400);
+    setTimeout(() => {
+      el.classList.add('fade');
+      el.addEventListener('transitionend', () => el.remove(), { once:true });
+    }, 2400);
   }
 
+  // ---------------------------------------------------------------------------
+  // Application state variables
+  // ---------------------------------------------------------------------------
   let mode = 'wysiwyg'; // 'wysiwyg' | 'source'
   let currentFileName = 'untitled.md';
-  let md, td;
-  let savedRange = null;
-  let frontmatter = {};
-  const DRAFT_KEY = 'draft';
+  let md, td; // markdown-it and turndown instances
+  let savedRange = null; // caret position when switching views
+  let frontmatter = {}; // YAML frontmatter data
+  const DRAFT_KEY = 'draft'; // localStorage key for unsaved work
   let lastSavedMd = '';
-  let dirty = false;
+  let dirty = false; // whether there are unsaved changes
   let scrollPos = 0;
 
   try {

--- a/assets/polyfills.js
+++ b/assets/polyfills.js
@@ -1,3 +1,6 @@
+// Minimal polyfills used by the editor for older browsers.
+
+// Fallback for structuredClone, which copies objects without references.
 if (typeof globalThis.structuredClone !== 'function') {
   globalThis.structuredClone = obj => JSON.parse(JSON.stringify(obj));
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,4 +1,7 @@
-/* Quiet, accessible UI */
+/* Main stylesheet for the Scriptor editor.
+   The goal is a quiet, accessible UI that works in light and dark modes. */
+
+/* Base color variables that apply to both themes */
 :root{
   --bg: #ffffff;
   --fg: #0f172a;
@@ -12,6 +15,7 @@
   --surface: #ffffff;
 }
 
+/* Light theme overrides */
 :root[data-theme="light"]{
   --bg: #ffffff;
   --fg: #0f172a;
@@ -25,6 +29,7 @@
   --surface: #ffffff;
 }
 
+/* Dark theme overrides */
 :root[data-theme="dark"]{
   --bg: #0b1020;
   --fg: #e5e7eb;

--- a/index.html
+++ b/index.html
@@ -1,19 +1,27 @@
 <!doctype html>
+<!-- Main page for the Scriptor Markdown editor -->
 <html lang="en-GB" data-theme="light">
 <head>
   <meta charset="utf-8">
+  <!-- Make the UI responsive on phones -->
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Scriptor — Markdown editor">
   <title>Scriptor — Markdown editor</title>
+  <!-- Global stylesheet and favicon -->
   <link rel="stylesheet" href="assets/style.css">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
 </head>
 <body>
+  <!-- Sticky toolbar at the top of the page -->
   <header class="ribbon" role="navigation" aria-label="Editor toolbar">
     <h1 class="visually-hidden">Scriptor</h1>
+    <!-- Groups of buttons that act like a word processor toolbar -->
     <nav role="toolbar" aria-label="Editor toolbar">
+      <!-- Hidden inputs used to load files and images -->
       <input id="fileInput" type="file" accept=".md,text/markdown,text/plain" hidden>
       <input id="imgInput" type="file" accept="image/*" hidden>
+
+      <!-- Undo/formatting buttons -->
       <div class="btn-group" role="group" aria-label="Formatting">
         <button id="btnUndo" class="btn" data-tip="Undo  Ctrl or Cmd+Z" aria-label="Undo">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#undo"/></svg>
@@ -29,6 +37,7 @@
         </button>
       </div>
 
+      <!-- Heading level shortcuts -->
       <div class="btn-group" role="group" aria-label="Headings">
         <button data-h="1" class="btn btn-h" data-tip="Heading 1  Ctrl or Cmd+1" aria-label="Heading 1">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#h1"/></svg>
@@ -44,8 +53,10 @@
         </button>
       </div>
 
+      <!-- Buttons that insert more complex content like tables or charts -->
       <div class="btn-group" role="group" aria-label="Insertions">
         <div class="table-wrap">
+          <!-- Table picker dialog -->
           <button id="btnTable" class="btn" data-tip="Insert table" aria-expanded="false" aria-controls="tablePicker" aria-label="Insert table">
             <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#table"/></svg>
           </button>
@@ -56,6 +67,7 @@
           </div>
         </div>
         <div class="chart-wrap">
+          <!-- Simple interface for building Mermaid diagrams -->
           <button id="btnChart" class="btn" data-tip="Insert Mermaid chart" aria-expanded="false" aria-controls="chartBuilder" aria-label="Insert chart">
             <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#chart"/></svg>
           </button>
@@ -82,6 +94,7 @@
             </div>
           </div>
         </div>
+        <!-- Shortcut buttons for images and links -->
         <button id="btnImage" class="btn" data-tip="Insert image" aria-label="Insert image">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#image"/></svg>
         </button>
@@ -92,6 +105,7 @@
 
       <span class="spacer" aria-hidden="true"></span>
 
+      <!-- File operations and export menu -->
       <button id="btnLoad" class="btn" data-tip="Open .md file" aria-label="Open">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Open</span>
       </button>
@@ -102,6 +116,7 @@
         <option value="docx">DOCX</option>
         <option value="html">HTML</option>
       </select>
+      <!-- YAML frontmatter editor -->
       <div class="frontmatter-wrap">
         <button id="btnFrontmatter" class="btn" data-tip="Edit frontmatter" aria-expanded="false" aria-controls="frontmatterEditor" aria-label="Frontmatter">
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Frontmatter</span>
@@ -118,12 +133,14 @@
           </div>
         </div>
       </div>
+      <!-- Toggle between WYSIWYG and raw Markdown source -->
       <button id="btnSource" class="btn" data-tip="Toggle advanced mode  Ctrl or Cmd+/" aria-pressed="false" aria-label="Advanced">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
       </button>
     </nav>
   </header>
 
+  <!-- Main editor area -->
   <main id="main">
     <section id="dropZone" class="surface" aria-label="Editor area">
       <div id="editor" class="editor" contenteditable="true" role="textbox" aria-multiline="true" spellcheck="true"></div>
@@ -132,6 +149,7 @@
     <div id="statusBar"></div>
   </main>
 
+  <!-- Always-visible list of keyboard shortcuts -->
   <aside id="shortcuts" class="shortcuts" aria-label="Keyboard shortcuts">
     <button id="toggleShortcuts" class="toggle" aria-expanded="true" aria-label="Hide shortcuts">×</button>
     <h2>Shortcuts</h2>
@@ -149,17 +167,18 @@
     </ul>
   </aside>
 
+  <!-- Toast container where short messages appear -->
   <div id="toasts" class="toasts" aria-live="polite" aria-atomic="true"></div>
 
-    <!-- Polyfills -->
+    <!-- Polyfills for older browsers -->
     <script defer src="assets/polyfills.js"></script>
-    <!-- Vendor libs -->
+    <!-- Vendor libraries that power the editor -->
     <script defer src="assets/vendor/markdown-it.min.js"></script>
     <script defer src="assets/vendor/purify.min.js"></script>
     <script defer src="assets/vendor/turndown.js"></script>
     <script defer src="assets/vendor/turndown-plugin-gfm.js"></script>
     <script defer src="assets/vendor/mermaid.min.js"></script>
-  <!-- App -->
+  <!-- Application logic -->
   <script defer src="assets/app.js"></script>
 
   <noscript>This editor needs JavaScript enabled.</noscript>

--- a/server.py
+++ b/server.py
@@ -1,8 +1,16 @@
+"""Tiny Flask wrapper around Pandoc for converting Markdown files."""
+
+# Standard library
 import subprocess
+
+# Third party
 from flask import Flask, request, Response, jsonify
 
+# Create the Flask application instance
 app = Flask(__name__)
 
+# Map requested output formats to the appropriate MIME type so the browser
+# knows what kind of file is being returned.
 FORMAT_TO_MIME = {
     'pdf': 'application/pdf',
     'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -12,15 +20,25 @@ FORMAT_TO_MIME = {
 
 @app.route('/api/convert', methods=['POST', 'OPTIONS'])
 def convert():
+    """Convert Markdown into another document format using Pandoc."""
+    # Handle CORS preflight requests with an empty 204 response
     if request.method == 'OPTIONS':
         return ('', 204)
+
+    # Parse incoming JSON and pull out the markdown text and desired format
     data = request.get_json(force=True) or {}
     markdown = data.get('markdown')
     fmt = data.get('format')
+
+    # Both fields are required, otherwise the client made a bad request
     if not markdown or not fmt:
         return jsonify({'error': 'Missing markdown or format'}), 400
+
+    # Build the pandoc command that reads from STDIN and writes the result to STDOUT
     args = ['pandoc', '--from=markdown', f'--to={fmt}', '--output=-']
+
     try:
+        # Run pandoc and capture its output without raising on non‑zero exit codes
         proc = subprocess.run(
             args,
             input=markdown.encode('utf-8'),
@@ -29,11 +47,17 @@ def convert():
             check=False
         )
     except FileNotFoundError:
+        # pandoc binary is missing from the system
         return jsonify({'error': 'Pandoc not installed'}), 500
+
     if proc.returncode != 0:
+        # Propagate pandoc errors back to the client
         return jsonify({'error': proc.stderr.decode('utf-8', errors='ignore')}), 500
+
+    # Determine the proper MIME type to use for the response body
     mime = FORMAT_TO_MIME.get(fmt, 'application/octet-stream')
     return Response(proc.stdout, mimetype=mime)
 
 if __name__ == '__main__':
+    # Expose the service to the host machine on port 8000
     app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- document server API usage and Pandoc invocation
- clarify structure of index and client scripts with inline comments
- explain theme variables and polyfills for maintainability

## Testing
- `python -m py_compile server.py`
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6ed42e4dc8332b91a635611db743f