### PR TITLE
Use bubbling events for tooltip listeners

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -101,14 +101,15 @@
 
   function handleTooltipLeave(e) {
     const target = e.target.closest('[data-tip]');
+    if (tooltipOwner && tooltipOwner.contains(e.relatedTarget)) return;
     if (!target || target !== tooltipOwner) return;
     hideTooltip();
   }
 
-  document.addEventListener('pointerenter', handleTooltipEnter, true);
-  document.addEventListener('focus', handleTooltipEnter, true);
-  document.addEventListener('pointerleave', handleTooltipLeave, true);
-  document.addEventListener('blur', handleTooltipLeave, true);
+  document.addEventListener('pointerover', handleTooltipEnter);
+  document.addEventListener('focusin', handleTooltipEnter);
+  document.addEventListener('pointerout', handleTooltipLeave);
+  document.addEventListener('focusout', handleTooltipLeave);
 
   // Prevent toolbar clicks from moving editor focus across input types
   function keepEditorFocus(e) {


### PR DESCRIPTION
## Summary
- Switch tooltip listeners to `pointerover`/`pointerout` and `focusin`/`focusout`
- Ignore pointer transitions within the same tooltip owner on leave

## Testing
- `NODE_PATH=$(npm root -g) node tooltip test script`

------
https://chatgpt.com/codex/tasks/task_e_68b6eefef3f08332869885ad9427e849