### PR TITLE
Allow overflow for toolbar button groups

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -95,7 +95,7 @@ body{
   .btn[aria-pressed="true"]{background:color-mix(in srgb, var(--surface) 92%, var(--edge) 8%)}
   .table-picker .close:hover{background:color-mix(in srgb, var(--surface) 92%, var(--edge) 8%)}
 }
-.btn-group{display:inline-flex; border:1px solid var(--edge); border-radius:.5rem; overflow:hidden}
+.btn-group{display:inline-flex; border:1px solid var(--edge); border-radius:.5rem; overflow:visible}
 .btn-group .btn{border:none; border-radius:0}
 .btn-group > *:not(:last-child){border-right:1px solid var(--edge)}
 .ico{width:18px; height:18px; display:inline-block}


### PR DESCRIPTION
## Summary
- Let `.btn-group` show overflow so popups like the table picker or chart builder aren't clipped

## Testing
- `node - <<'NODE'` with Playwright to open the page and verify bounding boxes of table picker, chart builder, and tooltips


------
https://chatgpt.com/codex/tasks/task_e_68b6f28df634833288c564a93d2ba09b