### PR TITLE
Render tooltips below toolbar buttons

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -77,8 +77,8 @@
       tooltipBox.textContent = target.dataset.tip;
       const rect = target.getBoundingClientRect();
       tooltipBox.style.left = window.scrollX + rect.left + rect.width / 2 + 'px';
-      tooltipBox.style.top = window.scrollY + rect.top + 'px';
-      tooltipBox.style.transform = 'translate(-50%, calc(-100% - 8px))';
+      tooltipBox.style.top = window.scrollY + rect.bottom + 'px';
+      tooltipBox.style.transform = 'translate(-50%, 8px)';
       tooltipBox.style.transition = tooltipOwner ? 'none' : '';
       tooltipBox.classList.add('show');
       tooltipOwner = target;


### PR DESCRIPTION
## Summary
- Anchor tooltip vertical position to element bottom
- Offset tooltip downward to keep it visible below buttons

## Testing
- `node - <<'NODE' ...` *(jsdom simulation of showTooltip)*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f487bb4c8332b1d15bd31c16b61a