### PR TITLE
Add browser-based Markdown linter with side panel

### DIFF
--- a/docs/lint/lint-glue.js
+++ b/docs/lint/lint-glue.js
@@ -1,0 +1,51 @@
+/* glue code: wire the linter to your page, no build step needed */
+
+/* Scriptor IDs */
+const MD_INPUT   = document.querySelector("#source");   // raw markdown source
+const PREVIEW_EL = document.querySelector("#editor");   // rendered editor
+
+function getMarkdown(){
+  if(MD_INPUT) return MD_INPUT.value;
+  return document.body.innerText || "";
+}
+
+function jumpTo(from, to){
+  if(!MD_INPUT) return;
+  MD_INPUT.focus();
+  MD_INPUT.setSelectionRange(from, to);
+  MD_INPUT.scrollTop = MD_INPUT.scrollHeight * (from / MD_INPUT.value.length);
+}
+
+function addLintButton(){
+  const btn = document.createElement("button");
+  btn.textContent = "Run lint";
+  btn.style.cssText = "position:fixed;right:360px;top:10px;z-index:10000;padding:6px 10px";
+  btn.onclick = () => LintUI.run({
+    getMarkdown,
+    container: PREVIEW_EL || document.body,
+    jumpTo,
+    config: {
+      sentenceWordLimit: 60,
+      bannedPhrases: {
+        "and/or":"choose one, and or or",
+        "etc.":"be specific, remove etc.",
+        "as appropriate":"say who decides, on what basis",
+        "from time to time":"state frequency or trigger"
+      },
+      extraStopTerms: ["FSB","IB","TCB","ANLA","PII","RAE"]
+    }
+  });
+  document.body.appendChild(btn);
+}
+
+document.addEventListener("DOMContentLoaded", addLintButton);
+
+if(MD_INPUT){
+  let t = null;
+  MD_INPUT.addEventListener("input", () => {
+    clearTimeout(t);
+    t = setTimeout(() => {
+      LintUI.run({ getMarkdown, container: PREVIEW_EL || document.body, jumpTo });
+    }, 1000);
+  });
+}

--- a/docs/lint/lint.css
+++ b/docs/lint/lint.css
@@ -1,0 +1,34 @@
+/* issue panel */
+#lint-panel {
+  position: fixed; top: 0; right: 0; width: 340px; height: 100vh;
+  background: #0f172a; color: #e5e7eb; border-left: 1px solid #1f2937;
+  font: 13px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial;
+  display: flex; flex-direction: column; z-index: 9999;
+}
+#lint-panel header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px; border-bottom: 1px solid #1f2937;
+}
+#lint-panel header h3 { margin: 0; font-size: 14px; }
+#lint-list { overflow: auto; padding: 8px 0; }
+.lint-item { padding: 8px 12px; border-bottom: 1px solid #1f2937; cursor: pointer; }
+.lint-item:hover { background: #111827; }
+.lint-item .loc { opacity: .7; font-size: 12px; }
+.lint-tag { display: inline-block; padding: 0 6px; margin-right: 6px; border-radius: 3px; font-size: 11px; }
+.tag-error { background: #7f1d1d; }
+.tag-warn  { background: #78350f; }
+.tag-info  { background: #1e3a8a; }
+
+/* highlight marks in preview */
+.lint-underline { text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: 3px; }
+.lint-error { text-decoration-color: #ef4444; }
+.lint-warn  { text-decoration-color: #f59e0b; }
+.lint-info  { text-decoration-color: #60a5fa; }
+
+/* tooltip */
+#lint-tip {
+  position: absolute; display: none; max-width: 420px;
+  background: #111827; color: #e5e7eb; border: 1px solid #374151;
+  padding: 8px 10px; border-radius: 6px; font-size: 12px; z-index: 10000;
+  box-shadow: 0 6px 20px rgba(0,0,0,.4);
+}

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -1,0 +1,142 @@
+/* Lightweight Markdown linter with side panel UI */
+
+const LintUI = (() => {
+  function run(opts = {}){
+    const md = (opts.getMarkdown ? opts.getMarkdown() : "") || "";
+    const cfg = Object.assign({
+      sentenceWordLimit: 40,
+      bannedPhrases: {},
+      extraStopTerms: []
+    }, opts.config || {});
+
+    const issues = [];
+
+    // Check for long sentences
+    const sentences = md.split(/(?<=[.!?])\s+/);
+    let pos = 0;
+    for(const s of sentences){
+      const words = s.trim().split(/\s+/).filter(Boolean);
+      if(words.length > cfg.sentenceWordLimit){
+        const start = md.indexOf(s, pos);
+        const end = start + s.length;
+        issues.push({
+          type: 'warn',
+          message: `Sentence longer than ${cfg.sentenceWordLimit} words (${words.length})`,
+          from: start,
+          to: end,
+          text: s
+        });
+      }
+      pos += s.length + 1;
+    }
+
+    // Banned phrases
+    for(const [phrase, hint] of Object.entries(cfg.bannedPhrases)){
+      const re = new RegExp(phrase, 'gi');
+      let m;
+      while((m = re.exec(md))){
+        issues.push({
+          type: 'error',
+          message: `Avoid "${phrase}" (${hint})`,
+          from: m.index,
+          to: m.index + m[0].length,
+          text: m[0]
+        });
+      }
+    }
+
+    // Extra stop terms
+    for(const term of cfg.extraStopTerms){
+      const re = new RegExp(term, 'gi');
+      let m;
+      while((m = re.exec(md))){
+        issues.push({
+          type: 'info',
+          message: `Contains stop term "${term}"`,
+          from: m.index,
+          to: m.index + m[0].length,
+          text: m[0]
+        });
+      }
+    }
+
+    renderPanel(issues, opts);
+    highlight(opts.container || document.body, issues);
+  }
+
+  function renderPanel(issues, opts){
+    document.querySelectorAll('#lint-panel, #lint-tip').forEach(el => el.remove());
+
+    const panel = document.createElement('div');
+    panel.id = 'lint-panel';
+    panel.innerHTML = `<header><h3>Lint results (${issues.length})</h3><button id="lint-close">×</button></header><div id="lint-list"></div>`;
+    const list = panel.querySelector('#lint-list');
+
+    const tip = document.createElement('div');
+    tip.id = 'lint-tip';
+    document.body.appendChild(tip);
+
+    issues.forEach((iss, i) => {
+      const item = document.createElement('div');
+      item.className = 'lint-item';
+      item.innerHTML = `<span class="lint-tag tag-${iss.type}">${iss.type}</span>${escapeHtml(iss.message)}<div class="loc">${iss.from}-${iss.to}</div>`;
+      item.addEventListener('click', () => {
+        if(typeof opts.jumpTo === 'function') opts.jumpTo(iss.from, iss.to);
+      });
+      item.addEventListener('mouseenter', e => {
+        tip.textContent = iss.message;
+        tip.style.display = 'block';
+        tip.style.top = (e.clientY + 12) + 'px';
+        tip.style.left = (e.clientX - tip.offsetWidth - 12) + 'px';
+      });
+      item.addEventListener('mouseleave', () => {
+        tip.style.display = 'none';
+      });
+      list.appendChild(item);
+    });
+
+    panel.querySelector('#lint-close').onclick = () => panel.remove();
+    document.body.appendChild(panel);
+  }
+
+  function highlight(container, issues){
+    if(!container) return;
+
+    container.querySelectorAll('.lint-underline').forEach(el => {
+      const parent = el.parentNode;
+      parent.replaceChild(document.createTextNode(el.textContent), el);
+      parent.normalize();
+    });
+
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null);
+    const nodes = [];
+    while(walker.nextNode()) nodes.push(walker.currentNode);
+
+    issues.forEach(iss => {
+      let start = iss.from, end = iss.to, count = 0;
+      for(const node of nodes){
+        const len = node.textContent.length;
+        if(count + len < start){
+          count += len;
+          continue;
+        }
+        const s = Math.max(0, start - count);
+        const e = Math.min(len, end - count);
+        if(s >= len) break;
+        const range = document.createRange();
+        range.setStart(node, s);
+        range.setEnd(node, e);
+        const span = document.createElement('span');
+        span.className = `lint-underline lint-${iss.type}`;
+        range.surroundContents(span);
+        break;
+      }
+    });
+  }
+
+  function escapeHtml(str){
+    return str.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  }
+
+  return { run };
+})();

--- a/index.html
+++ b/index.html
@@ -179,8 +179,12 @@
     <script defer src="assets/vendor/turndown-plugin-gfm.js"></script>
     <script defer src="assets/vendor/mermaid.min.js"></script>
   <!-- Application logic -->
-  <script defer src="assets/app.js"></script>
+    <script defer src="assets/app.js"></script>
 
-  <noscript>This editor needs JavaScript enabled.</noscript>
-</body>
+    <link rel="stylesheet" href="docs/lint/lint.css">
+    <script src="docs/lint/lint.js"></script>
+    <script src="docs/lint/lint-glue.js"></script>
+
+    <noscript>This editor needs JavaScript enabled.</noscript>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add lint UI assets and glue code for in-browser markdown linting
- integrate linter into main page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94e0e01448332930eb6771c3b0fbe