### PR TITLE
feat: theme-aware lint styles

### DIFF
--- a/docs/lint/lint.css
+++ b/docs/lint/lint.css
@@ -1,34 +1,34 @@
 /* issue panel */
 #lint-panel {
   position: fixed; top: 0; right: 0; width: 340px; height: 100vh;
-  background: #0f172a; color: #e5e7eb; border-left: 1px solid #1f2937;
+  background: var(--surface); color: var(--fg); border-left: 1px solid var(--edge);
   font: 13px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial;
   display: flex; flex-direction: column; z-index: 9999;
 }
 #lint-panel header {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 12px; border-bottom: 1px solid #1f2937;
+  padding: 10px 12px; border-bottom: 1px solid var(--edge);
 }
 #lint-panel header h3 { margin: 0; font-size: 14px; }
 #lint-list { overflow: auto; padding: 8px 0; }
-.lint-item { padding: 8px 12px; border-bottom: 1px solid #1f2937; cursor: pointer; }
-.lint-item:hover { background: #111827; }
+.lint-item { padding: 8px 12px; border-bottom: 1px solid var(--edge); cursor: pointer; }
+.lint-item:hover { background: var(--edge); }
 .lint-item .loc { opacity: .7; font-size: 12px; }
 .lint-tag { display: inline-block; padding: 0 6px; margin-right: 6px; border-radius: 3px; font-size: 11px; }
-.tag-error { background: #7f1d1d; }
-.tag-warn  { background: #78350f; }
-.tag-info  { background: #1e3a8a; }
+.tag-error { background: var(--warn); }
+.tag-warn  { background: var(--accent-2); }
+.tag-info  { background: var(--accent); }
 
 /* highlight marks in preview */
 .lint-underline { text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: 3px; }
-.lint-error { text-decoration-color: #ef4444; }
-.lint-warn  { text-decoration-color: #f59e0b; }
-.lint-info  { text-decoration-color: #60a5fa; }
+.lint-error { text-decoration-color: var(--warn); }
+.lint-warn  { text-decoration-color: var(--accent-2); }
+.lint-info  { text-decoration-color: var(--accent); }
 
 /* tooltip */
 #lint-tip {
   position: absolute; display: none; max-width: 420px;
-  background: #111827; color: #e5e7eb; border: 1px solid #374151;
+  background: var(--surface); color: var(--fg); border: 1px solid var(--edge);
   padding: 8px 10px; border-radius: 6px; font-size: 12px; z-index: 10000;
   box-shadow: 0 6px 20px rgba(0,0,0,.4);
 }


### PR DESCRIPTION
## Summary
- replace hard-coded colors in lint panel with theme variables
- use accent and warn variables for tag colors and underlines
- style lint tooltip with theme variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9535e74188332b7c41aba7ca403c6