### PR TITLE
Link lint panel items with highlights

### DIFF
--- a/docs/lint/lint.css
+++ b/docs/lint/lint.css
@@ -13,6 +13,7 @@
 #lint-list { overflow: auto; padding: 8px 0; }
 .lint-item { padding: 8px 12px; border-bottom: 1px solid var(--edge); cursor: pointer; }
 .lint-item:hover { background: var(--edge); }
+.lint-item.selected { background: var(--accent); color: var(--surface); }
 .lint-item .loc { opacity: .7; font-size: 12px; }
 .lint-tag { display: inline-block; padding: 0 6px; margin-right: 6px; border-radius: 3px; font-size: 11px; }
 .tag-error { background: var(--warn); }
@@ -24,6 +25,7 @@
 .lint-error { text-decoration-color: var(--warn); }
 .lint-warn  { text-decoration-color: var(--accent-2); }
 .lint-info  { text-decoration-color: var(--accent); }
+.lint-underline.active { background: var(--accent); color: var(--surface); }
 
 /* tooltip */
 #lint-tip {

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -79,9 +79,11 @@ const LintUI = (() => {
     issues.forEach((iss, i) => {
       const item = document.createElement('div');
       item.className = 'lint-item';
+      item.dataset.issue = i;
       item.innerHTML = `<span class="lint-tag tag-${iss.type}">${iss.type}</span>${escapeHtml(iss.message)}<div class="loc">${iss.from}-${iss.to}</div>`;
       item.addEventListener('click', () => {
         if(typeof opts.jumpTo === 'function') opts.jumpTo(iss.from, iss.to);
+        activateIssue(i);
       });
       item.addEventListener('mouseenter', e => {
         tip.textContent = iss.message;
@@ -112,7 +114,7 @@ const LintUI = (() => {
     const nodes = [];
     while(walker.nextNode()) nodes.push(walker.currentNode);
 
-    issues.forEach(iss => {
+    issues.forEach((iss, i) => {
       let start = iss.from, end = iss.to, count = 0;
       for(const node of nodes){
         const len = node.textContent.length;
@@ -128,8 +130,29 @@ const LintUI = (() => {
         range.setEnd(node, e);
         const span = document.createElement('span');
         span.className = `lint-underline lint-${iss.type}`;
+        span.dataset.issue = i;
+        span.addEventListener('click', () => activateIssue(i));
+        span.addEventListener('mouseenter', () => activateIssue(i));
         range.surroundContents(span);
         break;
+      }
+    });
+  }
+
+  function activateIssue(id){
+    document.querySelectorAll('.lint-item').forEach(it => {
+      if(it.dataset.issue == id){
+        it.classList.add('selected');
+        it.scrollIntoView({block: 'nearest'});
+      } else {
+        it.classList.remove('selected');
+      }
+    });
+    document.querySelectorAll('.lint-underline').forEach(sp => {
+      if(sp.dataset.issue == id){
+        sp.classList.add('active');
+      } else {
+        sp.classList.remove('active');
       }
     });
   }


### PR DESCRIPTION
## Summary
- Attach unique `data-issue` ids to lint panel items and preview underlines
- Highlight active issues via new `selected`/`active` classes and synchronized listeners
- Style selected lint items and active text highlights for better focus

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b953ecb7948332be0026c4bdd9c682