### PR TITLE
Add lint toolbar button

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -40,4 +40,7 @@
   <symbol id="search" viewBox="0 0 24 24">
     <path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16a6.471 6.471 0 004.23-1.57l.27.28v.79l5 5L20.49 19l-5-5zM9.5 14C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
   </symbol>
+  <symbol id="check" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19l12-12-1.41-1.41z"/>
+  </symbol>
 </svg>

--- a/docs/lint/lint-glue.js
+++ b/docs/lint/lint-glue.js
@@ -3,6 +3,7 @@
 /* Scriptor IDs */
 const MD_INPUT   = document.querySelector("#source");   // raw markdown source
 const PREVIEW_EL = document.querySelector("#editor");   // rendered editor
+const BTN_CHECK  = document.querySelector("#btnCheck"); // toolbar button
 
 function getMarkdown(){
   if(MD_INPUT) return MD_INPUT.value;
@@ -16,11 +17,8 @@ function jumpTo(from, to){
   MD_INPUT.scrollTop = MD_INPUT.scrollHeight * (from / MD_INPUT.value.length);
 }
 
-function addLintButton(){
-  const btn = document.createElement("button");
-  btn.textContent = "Run lint";
-  btn.style.cssText = "position:fixed;right:360px;top:10px;z-index:10000;padding:6px 10px";
-  btn.onclick = () => LintUI.run({
+function runLint(){
+  LintUI.run({
     getMarkdown,
     container: PREVIEW_EL || document.body,
     jumpTo,
@@ -35,17 +33,16 @@ function addLintButton(){
       extraStopTerms: ["FSB","IB","TCB","ANLA","PII","RAE"]
     }
   });
-  document.body.appendChild(btn);
 }
 
-document.addEventListener("DOMContentLoaded", addLintButton);
+if(BTN_CHECK){
+  BTN_CHECK.addEventListener("click", runLint);
+}
 
 if(MD_INPUT){
   let t = null;
   MD_INPUT.addEventListener("input", () => {
     clearTimeout(t);
-    t = setTimeout(() => {
-      LintUI.run({ getMarkdown, container: PREVIEW_EL || document.body, jumpTo });
-    }, 1000);
+    t = setTimeout(runLint, 1000);
   });
 }

--- a/index.html
+++ b/index.html
@@ -134,11 +134,14 @@
         </div>
       </div>
       <!-- Toggle between WYSIWYG and raw Markdown source -->
-      <button id="btnSource" class="btn" data-tip="Toggle advanced mode  Ctrl or Cmd+/" aria-pressed="false" aria-label="Advanced">
-        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
-      </button>
-    </nav>
-  </header>
+        <button id="btnSource" class="btn" data-tip="Toggle advanced mode  Ctrl or Cmd+/" aria-pressed="false" aria-label="Advanced">
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
+        </button>
+        <button id="btnCheck" class="btn" data-tip="Check document" aria-label="Check">
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#check"/></svg><span>Check</span>
+        </button>
+      </nav>
+    </header>
 
   <!-- Main editor area -->
   <main id="main">


### PR DESCRIPTION
## Summary
- add "Check" toolbar button with matching check icon
- remove fixed-position lint button injection
- wire toolbar button to run `LintUI`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b955fe433c8332b219e24ea32d48fc