### PR TITLE
Rename lint UI labels to check

### DIFF
--- a/docs/lint/lint-glue.js
+++ b/docs/lint/lint-glue.js
@@ -1,9 +1,10 @@
-/* glue code: wire the linter to your page, no build step needed */
+/* glue code: wire the text checker to your page, no build step needed
+   User-facing name: "Check text" */
 
 /* Scriptor IDs */
 const MD_INPUT   = document.querySelector("#source");   // raw markdown source
 const PREVIEW_EL = document.querySelector("#editor");   // rendered editor
-const BTN_CHECK  = document.querySelector("#btnCheck"); // toolbar button
+const BTN_CHECK  = document.querySelector("#btnCheck"); // toolbar button for "Check text"
 
 function getMarkdown(){
   if(MD_INPUT) return MD_INPUT.value;
@@ -17,7 +18,7 @@ function jumpTo(from, to){
   MD_INPUT.scrollTop = MD_INPUT.scrollHeight * (from / MD_INPUT.value.length);
 }
 
-function runLint(){
+function runCheck(){
   LintUI.run({
     getMarkdown,
     container: PREVIEW_EL || document.body,
@@ -36,13 +37,13 @@ function runLint(){
 }
 
 if(BTN_CHECK){
-  BTN_CHECK.addEventListener("click", runLint);
+  BTN_CHECK.addEventListener("click", runCheck);
 }
 
 if(MD_INPUT){
   let t = null;
   MD_INPUT.addEventListener("input", () => {
     clearTimeout(t);
-    t = setTimeout(runLint, 1000);
+    t = setTimeout(runCheck, 1000);
   });
 }

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -1,4 +1,5 @@
-/* Lightweight Markdown linter with side panel UI */
+/* Lightweight Markdown linter with side panel UI
+   User-facing name: "Check" */
 
 const LintUI = (() => {
   function run(opts = {}){
@@ -83,7 +84,7 @@ const LintUI = (() => {
 
     const panel = document.createElement('div');
     panel.id = 'lint-panel';
-    panel.innerHTML = `<header><h3>Lint results (${issues.length})</h3><button id="lint-close">×</button></header><div id="lint-list"></div>`;
+    panel.innerHTML = `<header><h3>Check results (${issues.length})</h3><button id="lint-close">×</button></header><div id="lint-list"></div>`;
     const list = panel.querySelector('#lint-list');
 
     const tip = document.createElement('div');


### PR DESCRIPTION
## Summary
- Update lint glue script to reflect "Check text" terminology
- Replace panel heading with "Check results" and note new user-facing name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b956bd64cc833292e911333394b257