### PR TITLE
Fix linter WYSIWYG handling and literal banned phrases

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -263,6 +263,8 @@
     if (fmText) mdOut = `---\n${fmText}\n---\n\n` + mdOut;
     return mdOut;
   }
+  // expose for external scripts like the linter
+  window.getCurrentMarkdown = getCurrentMarkdown;
 
   function saveDraft(mdText) {
     try { localStorage.setItem(DRAFT_KEY, mdText); } catch (_) {}

--- a/docs/lint/lint-glue.js
+++ b/docs/lint/lint-glue.js
@@ -7,7 +7,9 @@ const PREVIEW_EL = document.querySelector("#editor");   // rendered editor
 const BTN_CHECK  = document.querySelector("#btnCheck"); // toolbar button for "Check text"
 
 function getMarkdown(){
-  if(MD_INPUT) return MD_INPUT.value;
+  if (MD_INPUT && MD_INPUT.value.trim()) return MD_INPUT.value;
+  if (window.getCurrentMarkdown) return window.getCurrentMarkdown();
+  if (PREVIEW_EL) return PREVIEW_EL.innerText || "";
   return document.body.innerText || "";
 }
 

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -41,7 +41,9 @@ const LintUI = (() => {
 
     // Banned phrases
     for(const [phrase, hint] of Object.entries(cfg.bannedPhrases)){
-      const re = new RegExp(phrase, 'gi');
+      // Escape special regex characters so phrases are matched literally
+      const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(escaped, 'gi');
       let m;
       while((m = re.exec(md))){
         const loc = toLineCol(m.index);


### PR DESCRIPTION
## Summary
- expose `getCurrentMarkdown` on `window`
- teach lint glue to pull WYSIWYG markdown when textarea is empty
- escape banned phrases so special characters aren't treated as patterns

## Testing
- `node -e "require('./docs/lint/lint.js')"`
- `node -e "require('./docs/lint/lint-glue.js')"` *(fails: ReferenceError: document is not defined)*
- `node -e "require('./assets/app.js')"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b958474fdc8332bdad6da6f6c2e609