### PR TITLE
feat(lint): add issue type icons

### DIFF
--- a/docs/lint/lint.css
+++ b/docs/lint/lint.css
@@ -15,7 +15,8 @@
 .lint-item:hover { background: var(--edge); }
 .lint-item.selected { background: var(--accent); color: var(--surface); }
 .lint-item .loc { opacity: .7; font-size: 12px; }
-.lint-tag { display: inline-block; padding: 0 6px; margin-right: 6px; border-radius: 3px; font-size: 11px; }
+.lint-tag { display: inline-flex; align-items: center; gap: 4px; padding: 0 6px; margin-right: 6px; border-radius: 3px; font-size: 11px; }
+.lint-icon { width: 12px; height: 12px; display: inline-block; line-height: 1; }
 .tag-error { background: var(--warn); }
 .tag-warn  { background: var(--accent-2); }
 .tag-info  { background: var(--accent); }

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -93,12 +93,15 @@ const LintUI = (() => {
     tip.id = 'lint-tip';
     document.body.appendChild(tip);
 
+    const icons = { error: '⛔', warn: '⚠️', info: 'ℹ️' };
+
     issues.forEach((iss, i) => {
       const item = document.createElement('div');
       item.className = 'lint-item';
       item.dataset.issue = i;
       const loc = `Line ${iss.line}${iss.column ? ':' + iss.column : ''}`;
-      item.innerHTML = `<span class="lint-tag tag-${iss.type}">${iss.type}</span>${escapeHtml(iss.message)}<div class="loc">${loc}</div>`;
+      const icon = icons[iss.type] || '';
+      item.innerHTML = `<span class="lint-tag tag-${iss.type}"><span class="lint-icon">${icon}</span>${iss.type}</span>${escapeHtml(iss.message)}<div class="loc">${loc}</div>`;
       item.addEventListener('click', () => {
         if(typeof opts.jumpTo === 'function') opts.jumpTo(iss.from, iss.to);
         activateIssue(i);


### PR DESCRIPTION
## Summary
- show issue type emojis in lint panel
- style tags and icons for better alignment

## Testing
- `node <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');
const lintSrc = fs.readFileSync('docs/lint/lint.js', 'utf8');
const dom = new JSDOM('<!doctype html><html><body></body></html>', {runScripts: 'dangerously'});
dom.window.eval(lintSrc + '\nwindow.LintUI = LintUI;');
dom.window.LintUI.run({getMarkdown: () => 'This sentence has way too many words in it to be short enough. banned phrase here and foo', config: {sentenceWordLimit: 5, bannedPhrases: {'banned phrase':'bad'}, extraStopTerms:['foo']}});
const tags = dom.window.document.querySelectorAll('.lint-tag');
tags.forEach(tag => console.log(tag.innerHTML));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b95b0e43f4833289daea87c14ae2aa