### PR TITLE
Standardize lint highlights and sync panel selection

### DIFF
--- a/docs/lint/lint.css
+++ b/docs/lint/lint.css
@@ -25,7 +25,7 @@
 .lint-underline { position: relative; }
 .lint-error { background: color-mix(in srgb, var(--warn) 25%, transparent); }
 .lint-warn  { background: color-mix(in srgb, var(--accent-2) 25%, transparent); }
-.lint-info  { box-shadow: inset 0 -2px var(--accent); }
+.lint-info  { background: color-mix(in srgb, var(--accent) 25%, transparent); }
 .lint-underline.active { background: var(--accent); color: var(--surface); box-shadow: none; }
 
 /* tooltip */

--- a/docs/lint/lint.js
+++ b/docs/lint/lint.js
@@ -154,6 +154,7 @@ const LintUI = (() => {
       }
     }
 
+    issues.sort((a, b) => a.from - b.from);
     renderPanel(issues, opts);
     highlight(container, issues);
   }
@@ -202,7 +203,6 @@ const LintUI = (() => {
   function highlight(container, issues){
     if(!container || !issues) return;
 
-    issues.sort((a, b) => a.from - b.from);
     let map = normalizeText(container).map;
 
     issues.forEach((iss, i) => {


### PR DESCRIPTION
## Summary
- Use consistent background colors for all lint severities
- Sort issues before rendering so panel items match highlighted text

## Testing
- `python -m py_compile server.py`
- `node --check docs/lint/lint.js`


------
https://chatgpt.com/codex/tasks/task_e_68b97d568a0483328d266fb6823dfe7f