### PR TITLE
Fix line numbers to match Markdown line count

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -272,8 +272,11 @@
   }
 
   function updateLineNumbers() {
-    const text = mode === 'source' ? (srcTA.value || '') : (editor.innerText || '');
-    const lines = text.split(/\n/).length;
+    // Use Markdown representation to determine line count so the gutter
+    // matches the actual document structure. innerText collapses multiple
+    // blank lines and results in an incorrect count for complex content.
+    const text = mode === 'source' ? (srcTA.value || '') : getCurrentMarkdown();
+    const lines = text.split(/\r?\n/).length;
     lineGutter.innerHTML = '';
     for (let i = 1; i <= lines; i++) {
       const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure line number gutter counts lines from Markdown source
- handle both source and WYSIWYG modes consistently

## Testing
- `python -m py_compile server.py`
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b97d8e4f8483328f12d7a773d25455