### PR TITLE
Align gutter with wrapped lines

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -272,11 +272,9 @@
   }
 
   function updateLineNumbers() {
-    // Use Markdown representation to determine line count so the gutter
-    // matches the actual document structure. innerText collapses multiple
-    // blank lines and results in an incorrect count for complex content.
-    const text = mode === 'source' ? (srcTA.value || '') : getCurrentMarkdown();
-    const lines = text.split(/\r?\n/).length;
+    const target = mode === 'source' ? srcTA : editor;
+    const lineHeight = parseFloat(getComputedStyle(target).lineHeight);
+    const lines = Math.ceil(target.scrollHeight / lineHeight);
     lineGutter.innerHTML = '';
     for (let i = 1; i <= lines; i++) {
       const div = document.createElement('div');

--- a/assets/style.css
+++ b/assets/style.css
@@ -199,7 +199,7 @@ body{
 /* Surface and editors */
 .surface{max-width:1100px; margin:1rem auto; padding:0 1rem}
 .editor-wrap{display:grid; grid-template-columns:auto 1fr}
-.line-gutter{display:none; padding:1.25rem .5rem; border:1px solid var(--edge); border-right:none; border-radius:.75rem 0 0 .75rem; background:var(--surface); text-align:right; font:.8rem/1.6 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; color:var(--muted); user-select:none}
+.line-gutter{display:none; padding:1.25rem .5rem; border:1px solid var(--edge); border-right:none; border-radius:.75rem 0 0 .75rem; background:var(--surface); text-align:right; font-size:.8rem; line-height:1.6rem; font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; color:var(--muted); user-select:none}
 .line-gutter div{padding:0 .25rem}
 .editor-wrap .editor,.editor-wrap .source{grid-column:2}
 .editor-wrap.show-line-numbers .line-gutter{display:block}


### PR DESCRIPTION
## Summary
- derive gutter line count from rendered height, using editor or source textarea as needed
- match gutter line height to editor while keeping a smaller font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b985a715f483328e300a685aff57d9