### PR TITLE
Add distinct icons for frontmatter and document check actions

### DIFF
--- a/assets/icons.svg
+++ b/assets/icons.svg
@@ -43,4 +43,10 @@
   <symbol id="check" viewBox="0 0 24 24">
     <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19l12-12-1.41-1.41z"/>
   </symbol>
+  <symbol id="frontmatter" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M4 4h16v2H4zm0 4h10v2H4zm0 4h16v2H4zm0 4h10v2H4z"/>
+  </symbol>
+  <symbol id="check-circle" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M12 2a10 10 0 100 20 10 10 0 000-20zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+  </symbol>
 </svg>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
       <!-- YAML frontmatter editor -->
       <div class="frontmatter-wrap">
         <button id="btnFrontmatter" class="btn" data-tip="Edit frontmatter" aria-expanded="false" aria-controls="frontmatterEditor" aria-label="Frontmatter">
-          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Frontmatter</span>
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#frontmatter"/></svg><span>Frontmatter</span>
         </button>
         <div id="frontmatterEditor" class="frontmatter-editor" role="dialog" aria-modal="false" aria-label="Edit frontmatter">
           <div class="row">
@@ -138,7 +138,7 @@
           <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Advanced</span>
         </button>
         <button id="btnCheck" class="btn" data-tip="Check document" aria-label="Check">
-          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#check"/></svg><span>Check</span>
+          <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#check-circle"/></svg><span>Check</span>
         </button>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- add dedicated frontmatter icon so it no longer reuses the open icon
- use check-circle icon for document check button

## Testing
- `python -m py_compile server.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98881ff0083329e61e53002b5608e