### PR TITLE
Allow numbered list regex without trailing space

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -960,7 +960,7 @@
 
     const first = block.firstChild;
     const text = block.textContent;
-    const match = text.match(/^(\d+(?:\.\d+)*)\s/);
+    const match = text.match(/^(\d+(?:\.\d+)*)(?:\s|$)/);
     if (!match) return;
 
     if (e.key === 'Enter') {


### PR DESCRIPTION
## Summary
- support numbered list detection without requiring a trailing space
- continue to parse segments via `match[1]` and slice with `match[0].length`

## Testing
- `node --check assets/app.js`
- `node - <<'NODE'
const regex = /^(\d+(?:\.\d+)*)(?:\s|$)/;
['1.1', '1.1 '].forEach(t => {
  const match = t.match(regex);
  if (match) {
    const segments = match[1].split('.').map(n => parseInt(n,10));
    segments[segments.length - 1]++;
    const prefix = segments.join('.') + ' ';
    console.log(`Enter on "${t}" -> "${prefix}"`);
  }
});
['1.1', '1.1 '].forEach(t => {
  const match = t.match(regex);
  if (match) {
    const segments = match[1].split('.').map(n => parseInt(n,10));
    segments.push(1);
    const prefix = segments.join('.') + ' ';
    const newText = prefix + t.slice(match[0].length);
    console.log(`Tab on "${t}" -> "${newText}"`);
  }
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bfe68f952c8332b61624402c831d74