### PR TITLE
Indent blank numbered line under previous sibling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -997,8 +997,11 @@
         sel.addRange(range);
         handleInput();
       } else if (/^\d+(?:\.\d+)*\s?$/.test(text)) {
+        const prev = block.previousElementSibling;
+        const prevMatch = prev && prev.textContent.match(/^(\d+(?:\.\d+)*)(?:\s|$)/);
+        if (!prevMatch) return;
         e.preventDefault();
-        const segments = match[1].split('.');
+        const segments = prevMatch[1].split('.');
         segments.push('1');
         const prefix = segments.join('.') + ' ';
         if (first && first.nodeType === 3) {


### PR DESCRIPTION
## Summary
- When indenting a blank numbered line, derive its child prefix from the previous sibling's numbering and append `.1`.
- Preserve existing Shift+Tab outdent behavior.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff6dbc9e0833293d43426318272d1