### PR TITLE
Add track changes diff viewer

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -318,3 +318,29 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
 @media (min-width:900px){
   body:not(.shortcuts-collapsed) #main{margin-right:220px}
 }
+
+/* Diff overlay */
+#diffOverlay{
+  position:fixed;
+  top:0;
+  left:0;
+  right:0;
+  bottom:0;
+  background:var(--surface);
+  color:var(--fg);
+  padding:1rem;
+  overflow:auto;
+  z-index:50;
+}
+#diffOverlay pre{white-space:pre-wrap; margin:0;}
+#diffOverlay .close{
+  position:absolute;
+  top:.5rem;
+  right:.5rem;
+  border:none;
+  background:#fff0;
+  font-size:1.5rem;
+  cursor:pointer;
+}
+#diffOverlay .added{background:rgba(16,185,129,.2);}
+#diffOverlay .removed{background:rgba(185,28,28,.2); text-decoration:line-through;}

--- a/index.html
+++ b/index.html
@@ -106,8 +106,12 @@
       <span class="spacer" aria-hidden="true"></span>
 
       <!-- File operations and export menu -->
+      <input id="diffInput" type="file" accept=".md,text/markdown,text/plain" hidden>
       <button id="btnLoad" class="btn" data-tip="Open .md file" aria-label="Open">
         <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#file"/></svg><span>Open</span>
+      </button>
+      <button id="btnDiff" class="btn" data-tip="Track changes" aria-label="Track changes">
+        <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#code"/></svg><span>Track</span>
       </button>
       <select id="exportMenu" class="btn" data-tip="Export document" aria-label="Export">
         <option value="" selected disabled>Export…</option>


### PR DESCRIPTION
## Summary
- add Track changes button and hidden input to compare Markdown files
- compute line-based diff and show read-only overlay highlighting adds/removes
- style diff overlay for easy review

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c004b8ac808332b13186ed571b7bde