### PR TITLE
Add diff styling classes for theme-aware changes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -319,6 +319,17 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
   body:not(.shortcuts-collapsed) #main{margin-right:220px}
 }
 
+/* Diff display */
+.diff-wrap{
+  margin:1rem 0;
+  padding:.5rem;
+  border:1px solid var(--edge);
+  border-radius:.25rem;
+  background:var(--surface);
+}
+.diff-add{background:var(--accent-2);}
+.diff-del{background:var(--warn); text-decoration:line-through;}
+
 /* Diff overlay */
 #diffOverlay{
   position:fixed;


### PR DESCRIPTION
## Summary
- Add `.diff-add` and `.diff-del` classes with theme variables for highlighting additions and deletions
- Introduce `.diff-wrap` container for diff display spacing and border styling

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c007c45210833290fd2589cd3b4b6c