### PR TITLE
Use renderDiff for inline word-level diffs

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -593,8 +593,13 @@
     if (!f) return;
     try {
       const txt = await f.text();
-      // First argument is the original file contents, second is the editor text
-      showDiff(txt, getCurrentMarkdown());
+      let wrap = document.querySelector('.diff-wrap');
+      if (!wrap) {
+        wrap = document.createElement('div');
+        wrap.className = 'diff-wrap';
+        editorWrap.insertAdjacentElement('afterend', wrap);
+      }
+      wrap.innerHTML = renderDiff(txt, getCurrentMarkdown());
     } catch(err) {
       console.error(err);
       toast('Failed to read diff file', 'warn');
@@ -602,63 +607,6 @@
       diffInput.value = '';
     }
   });
-
-  function showDiff(originalText, editorText) {
-    const diffs = diffLines(originalText, editorText);
-    const html = diffs.map(part => {
-      const esc = escapeHtml(part.line);
-      if (part.type === 'add') return `<div class="added">+ ${esc}</div>`;
-      if (part.type === 'del') return `<div class="removed">- ${esc}</div>`;
-      return `<div>${esc}</div>`;
-    }).join('\n');
-    displayDiff(html);
-  }
-
-  function diffLines(originalText, updatedText) {
-    const aL = originalText.split(/\r?\n/);
-    const bL = updatedText.split(/\r?\n/);
-    const m = aL.length, n = bL.length;
-    const dp = Array.from({length: m + 1}, () => Array(n + 1).fill(0));
-    for (let i = m - 1; i >= 0; i--) {
-      for (let j = n - 1; j >= 0; j--) {
-        if (aL[i] === bL[j]) dp[i][j] = dp[i + 1][j + 1] + 1;
-        else dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
-      }
-    }
-    const out = [];
-    let i = 0, j = 0;
-    while (i < m && j < n) {
-      if (aL[i] === bL[j]) { out.push({type:'ctx', line:aL[i++]}); j++; }
-      else if (dp[i + 1][j] >= dp[i][j + 1]) out.push({type:'del', line:aL[i++]});
-      else out.push({type:'add', line:bL[j++]});
-    }
-    while (i < m) out.push({type:'del', line:aL[i++]});
-    while (j < n) out.push({type:'add', line:bL[j++]});
-    return out;
-  }
-
-  function escapeHtml(str) {
-    const map = {'&':'&amp;','<':'&lt;','>':'&gt;'};
-    return str.replace(/[&<>]/g, ch => map[ch]);
-  }
-
-  function displayDiff(html) {
-    let overlay = document.getElementById('diffOverlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'diffOverlay';
-      const close = document.createElement('button');
-      close.textContent = '×';
-      close.className = 'close';
-      close.addEventListener('click', () => overlay.remove());
-      overlay.appendChild(close);
-      const pre = document.createElement('pre');
-      overlay.appendChild(pre);
-      document.body.appendChild(overlay);
-    }
-    const pre = overlay.querySelector('pre');
-    pre.innerHTML = html;
-  }
 
   // Drag and drop
   ['dragenter','dragover'].forEach(ev => dropZone.addEventListener(ev, e => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -329,29 +329,3 @@ table[contenteditable="false"] td[contenteditable="true"]{caret-color:auto}
 }
 .diff-add{background:var(--accent-2);}
 .diff-del{background:var(--warn); text-decoration:line-through;}
-
-/* Diff overlay */
-#diffOverlay{
-  position:fixed;
-  top:0;
-  left:0;
-  right:0;
-  bottom:0;
-  background:var(--surface);
-  color:var(--fg);
-  padding:1rem;
-  overflow:auto;
-  z-index:50;
-}
-#diffOverlay pre{white-space:pre-wrap; margin:0;}
-#diffOverlay .close{
-  position:absolute;
-  top:.5rem;
-  right:.5rem;
-  border:none;
-  background:#fff0;
-  font-size:1.5rem;
-  cursor:pointer;
-}
-#diffOverlay .added{background:rgba(16,185,129,.2);}
-#diffOverlay .removed{background:rgba(185,28,28,.2); text-decoration:line-through;}


### PR DESCRIPTION
## Summary
- Replace custom line-diff logic with renderDiff for word-level comparisons
- Display file comparison results inline with `.diff-add`/`.diff-del` highlighting
- Remove obsolete diff overlay styles and helpers

## Testing
- `node --check assets/app.js`
- `python -m py_compile server.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c00cc5713c8332bf0291f0cf091d74