### PR TITLE
Clarify renderDiff usage and document diff classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ The server accepts `POST /api/convert` with JSON `{ markdown, format }` and stre
 ## Outline numbering
 
 Lines that begin with a dotted number sequence such as `1.2.3 ` are treated as an outline. Press **Enter** to insert a new line with the last segment incremented. Use **Tab** to deepen the outline (appending `.1`) and **Shift+Tab** to move back up a level. The caret remains after the inserted prefix so you can continue typing immediately.
+
+## Diff styling
+
+When comparing versions, deletions are wrapped with the `.diff-del` class and insertions with `.diff-add`.

--- a/assets/app.js
+++ b/assets/app.js
@@ -155,18 +155,18 @@
   let scrollPos = 0;
   let diffMode = false;
   let storedEditorHTML = '';
-  let diffBaseline = '';
+  let baselineText = '';
 
   function escapeHtml(str) {
     return str.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
   }
 
-  // Render an HTML diff where `originalText` is the baseline and `updatedText`
-  // represents the new editor content.
-  function renderDiff(originalText, updatedText) {
+  // Render an HTML diff where `baselineText` is the original content and
+  // `editedText` represents the new editor content.
+  function renderDiff(baselineText, editedText) {
     if (!window.diff_match_patch) return '';
     const dmp = new diff_match_patch();
-    const diffs = dmp.diff_main(originalText || '', updatedText || '');
+    const diffs = dmp.diff_main(baselineText || '', editedText || '');
     dmp.diff_cleanupSemantic(diffs);
     return diffs.map(([op, data]) => {
       const text = escapeHtml(data);
@@ -570,11 +570,11 @@
     }
   });
 
-  function activateDiff(baseline) {
+  function activateDiff(baselineContent) {
     if (diffMode) deactivateDiff();
-    diffBaseline = baseline;
+    baselineText = baselineContent;
     storedEditorHTML = editor.innerHTML;
-    editor.innerHTML = renderDiff(diffBaseline, getCurrentMarkdown());
+    editor.innerHTML = renderDiff(baselineText, getCurrentMarkdown());
     editor.contentEditable = 'false';
     diffMode = true;
     btnDiff.setAttribute('aria-pressed', 'true');
@@ -585,7 +585,7 @@
     editor.innerHTML = storedEditorHTML;
     editor.contentEditable = 'true';
     diffMode = false;
-    diffBaseline = '';
+    baselineText = '';
     storedEditorHTML = '';
     btnDiff.setAttribute('aria-pressed', 'false');
   }


### PR DESCRIPTION
## Summary
- Rename renderDiff parameters to `baselineText` and `editedText` and store baseline in `baselineText` for clarity.
- Update call sites to ensure baseline is passed first when rendering diffs.
- Document that deletions use `.diff-del` and insertions use `.diff-add`.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0163e6a848332af45c4dcde43688d