### PR TITLE
Render diff segments as sanitized Markdown

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -157,10 +157,6 @@
   let storedEditorHTML = '';
   let baselineText = '';
 
-  function escapeHtml(str) {
-    return str.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
-  }
-
   // Render an HTML diff where `baselineText` is the original content and
   // `editedText` represents the new editor content.
   function renderDiff(baselineText, editedText) {
@@ -169,10 +165,10 @@
     const diffs = dmp.diff_main(baselineText || '', editedText || '');
     dmp.diff_cleanupSemantic(diffs);
     return diffs.map(([op, data]) => {
-      const text = escapeHtml(data);
-      if (op === 1) return `<span class="diff-add">${text}</span>`;
-      if (op === -1) return `<span class="diff-del">${text}</span>`;
-      return text;
+      const html = DOMPurify.sanitize(md.renderInline(data || ''));
+      if (op === 1) return `<span class="diff-add">${html}</span>`;
+      if (op === -1) return `<span class="diff-del">${html}</span>`;
+      return html;
     }).join('');
   }
 


### PR DESCRIPTION
## Summary
- Render diff segments using markdown-it and sanitize with DOMPurify
- Remove HTML escaping so Markdown formatting is preserved

## Testing
- `node <<'NODE'
const assert = require('assert');
const { JSDOM } = require('jsdom');
const { diff_match_patch } = require('diff-match-patch');
const { window } = new JSDOM('<!doctype html><div id="editor"></div>');
window.diff_match_patch = diff_match_patch;
global.window = window;
const createDOMPurify = require('dompurify');
const markdownit = require('markdown-it');
const DOMPurify = createDOMPurify(window);
const md = markdownit({ html:false, linkify:true, breaks:false }).enable(['table','strikethrough']);
function renderDiff(baselineText, editedText) {
  if (!window.diff_match_patch) return '';
  const dmp = new diff_match_patch();
  const diffs = dmp.diff_main(baselineText || '', editedText || '');
  dmp.diff_cleanupSemantic(diffs);
  return diffs.map(([op, data]) => {
    const html = DOMPurify.sanitize(md.renderInline(data || ''));
    if (op === 1) return `<span class="diff-add">${html}</span>`;
    if (op === -1) return `<span class="diff-del">${html}</span>`;
    return html;
  }).join('');
}
const editor = window.document.getElementById('editor');
let diffMode = false;
let storedEditorHTML = '';
let baselineText = '';
let editedMd = 'Hello world and **more**';
editor.innerHTML = md.render(editedMd);
function getCurrentMarkdown(){ return editedMd; }
function activateDiff(baselineContent) {
  if (diffMode) deactivateDiff();
  baselineText = baselineContent;
  storedEditorHTML = editor.innerHTML;
  editor.innerHTML = renderDiff(baselineText, getCurrentMarkdown());
  editor.contentEditable = 'false';
  diffMode = true;
}
function deactivateDiff() {
  if (!diffMode) return;
  editor.innerHTML = storedEditorHTML;
  editor.contentEditable = 'true';
  diffMode = false;
  baselineText = '';
  storedEditorHTML = '';
}
activateDiff('Hello world');
assert(editor.innerHTML.includes('diff-add') || editor.innerHTML.includes('diff-del'), 'diff markers inserted');
assert(editor.innerHTML.includes('<strong>more</strong>'), 'markdown rendered as HTML');
deactivateDiff();
assert(!editor.innerHTML.includes('diff-add') && !editor.innerHTML.includes('diff-del'), 'diff markers removed');
assert(editor.innerHTML === md.render(editedMd), 'original HTML restored');
console.log('diff functions ok');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c0197cbd2883329ba3adf951028a0f